### PR TITLE
Handle invalid durations

### DIFF
--- a/changelog/@unreleased/pr-17.v2.yml
+++ b/changelog/@unreleased/pr-17.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Handline invalid durations
+  links:
+  - https://github.com/palantir/deadlines-java/pull/17


### PR DESCRIPTION
## Before this PR

```
java.lang.NumberFormatException:
	at java.base/jdk.internal.math.FloatingDecimal.readJavaFormatString(FloatingDecimal.java:2054)
	at java.base/jdk.internal.math.FloatingDecimal.parseDouble(FloatingDecimal.java:110)
	at java.base/java.lang.Double.parseDouble(Double.java:792)
	at com.palantir.deadlines.Deadlines.headerValueToDuration(Deadlines.java:181)
	at java.base/java.util.Optional.map(Optional.java:260)
	at com.palantir.deadlines.Deadlines.parseFromRequest(Deadlines.java:127)
```


## After this PR

Properly treat invalid formatted deadlines as not specified