### PR TITLE
Optimize Deadlines::tryParseSecondsToNanoseconds

### DIFF
--- a/changelog/@unreleased/pr-19.v2.yml
+++ b/changelog/@unreleased/pr-19.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Optimize Deadlines::tryParseSecondsToNanoseconds
+  links:
+  - https://github.com/palantir/deadlines-java/pull/19

--- a/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
@@ -17,8 +17,8 @@
 package com.palantir.deadlines;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.CharMatcher;
 import com.google.common.base.Strings;
-import com.google.common.primitives.Doubles;
 import com.google.common.util.concurrent.RateLimiter;
 import com.palantir.deadlines.DeadlineMetrics.Expired_Cause;
 import com.palantir.deadlines.api.DeadlinesHttpHeaders;
@@ -43,6 +43,8 @@ public final class Deadlines {
 
     private static final TraceLocal<ProvidedDeadline> deadlineState = TraceLocal.of();
     private static final DeadlineMetrics metrics = DeadlineMetrics.of(SharedTaggedMetricRegistries.getSingleton());
+    private static final CharMatcher decimalMatcher =
+            CharMatcher.inRange('0', '9').or(CharMatcher.is('.')).precomputed();
 
     /**
      * Get the amount of time remaining for the current deadline.
@@ -191,23 +193,28 @@ public final class Deadlines {
     @Nullable
     @VisibleForTesting
     static Long tryParseSecondsToNanoseconds(String value) {
-        if (Strings.isNullOrEmpty(value)) {
+        String normalized = Strings.nullToEmpty(value).trim();
+        if (normalized.isEmpty()) {
             return null;
         }
 
-        Double seconds = Doubles.tryParse(value);
-        if (seconds == null) {
-            if (log.isWarnEnabled()) {
-                if (logLimiter.tryAcquire()) {
-                    log.warn("Failed to parse 'Expect-Within' header value", SafeArg.of("value", value));
-                } else if (log.isDebugEnabled()) {
-                    log.debug("Failed to parse 'Expect-Within' header value", SafeArg.of("value", value));
+        if (decimalMatcher.matchesAllOf(normalized)) {
+            try {
+                double seconds = Double.parseDouble(normalized);
+                return (long) (seconds * 1e9d);
+            } catch (NumberFormatException e) {
+                if (log.isWarnEnabled()) {
+                    if (logLimiter.tryAcquire()) {
+                        log.warn("Failed to parse 'Expect-Within' header value", SafeArg.of("value", value));
+                    } else if (log.isDebugEnabled()) {
+                        log.debug("Failed to parse 'Expect-Within' header value", SafeArg.of("value", value), e);
+                    }
                 }
+                return null;
             }
-            return null;
         }
 
-        return (long) (seconds * 1e9d);
+        return null;
     }
 
     public interface RequestEncodingAdapter<REQUEST> {

--- a/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
@@ -193,27 +193,24 @@ public final class Deadlines {
     @Nullable
     @VisibleForTesting
     static Long tryParseSecondsToNanoseconds(String value) {
+        NumberFormatException exception = null;
         String normalized = Strings.nullToEmpty(value).trim();
-        if (normalized.isEmpty()) {
-            return null;
-        }
-
-        if (decimalMatcher.matchesAllOf(normalized)) {
+        if (!normalized.isEmpty() && decimalMatcher.matchesAllOf(normalized)) {
             try {
                 double seconds = Double.parseDouble(normalized);
                 return (long) (seconds * 1e9d);
             } catch (NumberFormatException e) {
-                if (log.isWarnEnabled()) {
-                    if (logLimiter.tryAcquire()) {
-                        log.warn("Failed to parse 'Expect-Within' header value", SafeArg.of("value", value));
-                    } else if (log.isDebugEnabled()) {
-                        log.debug("Failed to parse 'Expect-Within' header value", SafeArg.of("value", value), e);
-                    }
-                }
-                return null;
+                exception = e;
             }
         }
 
+        if (log.isWarnEnabled()) {
+            if (logLimiter.tryAcquire()) {
+                log.warn("Failed to parse 'Expect-Within' header value", SafeArg.of("value", value));
+            } else if (log.isDebugEnabled()) {
+                log.debug("Failed to parse 'Expect-Within' header value", SafeArg.of("value", value), exception);
+            }
+        }
         return null;
     }
 

--- a/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
+++ b/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class DeadlinesTest {
@@ -43,15 +44,22 @@ class DeadlinesTest {
         assertThat(headerValue).isEqualTo("1.523");
     }
 
-    @Test
-    public void test_header_value_to_duration() {
-        assertThat(Deadlines.tryParseSecondsToNanoseconds("1.523"))
-                .isNotNull()
-                .isEqualTo(Duration.ofMillis(1523).toNanos());
+    @ParameterizedTest
+    @CsvSource({
+        "1, 1000000000",
+        "' 2. ', 2000000000",
+        "3.0, 3000000000",
+        "3.1, 3100000000",
+        "1234567890.12345, 1234567890123450112",
+        "1.523, 1523000000",
+        "'   1.523  ', 1523000000",
+    })
+    public void test_header_value_to_duration(String input, long expectedNanos) {
+        assertThat(Deadlines.tryParseSecondsToNanoseconds(input)).isNotNull().isEqualTo(expectedNanos);
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"", " ", ",", ".", "d"})
+    @ValueSource(strings = {"", " ", ",", ".", "d", " 1,234", "-1.234", "1.234e5"})
     public void test_invalid_header_value_to_duration(String headerValue) {
         assertThat(Deadlines.tryParseSecondsToNanoseconds(headerValue)).isNull();
     }

--- a/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
+++ b/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
@@ -55,11 +55,14 @@ class DeadlinesTest {
         "'   1.523  ', 1523000000",
     })
     public void test_header_value_to_duration(String input, long expectedNanos) {
-        assertThat(Deadlines.tryParseSecondsToNanoseconds(input)).isNotNull().isEqualTo(expectedNanos);
+        assertThat(Deadlines.tryParseSecondsToNanoseconds(input))
+                .isNotNull()
+                .isEqualTo(expectedNanos)
+                .isEqualTo(Math.round(Double.parseDouble(input) * 1_000_000_000L));
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"", " ", ",", ".", "d", " 1,234", "-1.234", "1.234e5"})
+    @ValueSource(strings = {"", " ", ",", ".", "d", "1,234", "-1.234", "1.234e5"})
     public void test_invalid_header_value_to_duration(String headerValue) {
         assertThat(Deadlines.tryParseSecondsToNanoseconds(headerValue)).isNull();
     }


### PR DESCRIPTION
## Before this PR

https://github.com/palantir/deadlines-java/pull/17#discussion_r1942363514 updated to use Guava `Doubles.tryParse` which performs regex string validation before attempting `Double.parseDouble`.

## After this PR

Use stricter digit `[0-9]` or period `.` character matcher to validate only positive decimal seconds value.