### PR TITLE
Revert "Deadlines.encodeToRequest checks for existing headers on the request"

### DIFF
--- a/changelog/@unreleased/pr-20.v2.yml
+++ b/changelog/@unreleased/pr-20.v2.yml
@@ -1,5 +1,0 @@
-type: improvement
-improvement:
-  description: Deadlines.encodeToRequest checks for existing headers on the request
-  links:
-  - https://github.com/palantir/deadlines-java/pull/20

--- a/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
@@ -93,14 +93,6 @@ public final class Deadlines {
      */
     public static <T> void encodeToRequest(
             Duration proposedDeadline, T request, RequestEncodingAdapter<? super T> adapter) {
-        if (adapter.containsHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN)) {
-            if (log.isDebugEnabled()) {
-                log.debug(
-                        "Outgoing request already contains an Expect-Within header, current state will not be encoded");
-            }
-            return;
-        }
-
         Optional<RemainingDeadline> deadlineFromState = getRemainingDeadlineInternal();
         long proposedDeadlineNanos = proposedDeadline.toNanos();
         if (deadlineFromState.isEmpty()) {
@@ -220,10 +212,6 @@ public final class Deadlines {
 
     public interface RequestEncodingAdapter<REQUEST> {
         void setHeader(REQUEST request, String headerName, String headerValue);
-
-        default boolean containsHeader(REQUEST request, String headerName) {
-            return false;
-        }
     }
 
     public interface RequestDecodingAdapter<REQUEST> {

--- a/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
+++ b/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
@@ -16,7 +16,7 @@
 
 package com.palantir.deadlines;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import com.codahale.metrics.Meter;
 import com.palantir.deadlines.DeadlineMetrics.Expired_Cause;
@@ -136,30 +136,6 @@ class DeadlinesTest {
     }
 
     @Test
-    public void encode_to_request_which_already_contains_valid_deadline_header() {
-        try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
-            Map<String, String> outboundRequest = new HashMap<>();
-            String originalValue = "60.1";
-            outboundRequest.put(DeadlinesHttpHeaders.EXPECT_WITHIN, originalValue);
-            Duration providedDeadline = Duration.ofSeconds(2);
-            Deadlines.encodeToRequest(providedDeadline, outboundRequest, DummyRequestEncoder.INSTANCE);
-            assertThat(outboundRequest).containsEntry(DeadlinesHttpHeaders.EXPECT_WITHIN, originalValue);
-        }
-    }
-
-    @Test
-    public void encode_to_request_which_already_contains_invalid_deadline_header() {
-        try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
-            Map<String, String> outboundRequest = new HashMap<>();
-            String originalValue = "foo";
-            outboundRequest.put(DeadlinesHttpHeaders.EXPECT_WITHIN, originalValue);
-            Duration providedDeadline = Duration.ofSeconds(2);
-            Deadlines.encodeToRequest(providedDeadline, outboundRequest, DummyRequestEncoder.INSTANCE);
-            assertThat(outboundRequest).containsEntry(DeadlinesHttpHeaders.EXPECT_WITHIN, originalValue);
-        }
-    }
-
-    @Test
     public void parse_from_request_noop_when_no_header_present() {
         try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
             Map<String, String> request = new HashMap<>();
@@ -262,11 +238,6 @@ class DeadlinesTest {
         @Override
         public void setHeader(Map<String, String> headers, String headerName, String headerValue) {
             headers.put(headerName, headerValue);
-        }
-
-        @Override
-        public boolean containsHeader(Map<String, String> stringStringMap, String headerName) {
-            return stringStringMap.containsKey(headerName);
         }
     }
 


### PR DESCRIPTION
Reverts palantir/deadlines-java#20

this hasn't been released, and won't work cleanly with the dialogue implementation that currently operates on a builder (no accessor to check current headers).