### PR TITLE
add ability to disable deadline propagation

### DIFF
--- a/changelog/@unreleased/pr-42.v2.yml
+++ b/changelog/@unreleased/pr-42.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: add ability to disable deadline propagation
+  links:
+  - https://github.com/palantir/deadlines-java/pull/42

--- a/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
@@ -21,7 +21,7 @@ import com.google.common.base.CharMatcher;
 import com.google.common.base.Strings;
 import com.google.common.util.concurrent.RateLimiter;
 import com.palantir.deadlines.DeadlineMetrics.Expired_Cause;
-import com.palantir.deadlines.DeadlineMetrics.Expired_PropagationDisabled;
+import com.palantir.deadlines.DeadlineMetrics.Expired_Intent;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
@@ -199,13 +199,8 @@ public final class Deadlines {
         if (deadline <= 0) {
             // expired
             Expired_Cause cause = internal ? Expired_Cause.INTERNAL : Expired_Cause.EXTERNAL;
-            Expired_PropagationDisabled propagationDisabled =
-                    disablePropagation ? Expired_PropagationDisabled.TRUE : Expired_PropagationDisabled.FALSE;
-            metrics.expired()
-                    .cause(cause)
-                    .propagationDisabled(propagationDisabled)
-                    .build()
-                    .mark();
+            Expired_Intent intent = disablePropagation ? Expired_Intent.IGNORE : Expired_Intent.PROPAGATE;
+            metrics.expired().cause(cause).intent(intent).build().mark();
             // TODO(blaub): throw exception instead of return
         }
     }

--- a/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
@@ -21,6 +21,7 @@ import com.google.common.base.CharMatcher;
 import com.google.common.base.Strings;
 import com.google.common.util.concurrent.RateLimiter;
 import com.palantir.deadlines.DeadlineMetrics.Expired_Cause;
+import com.palantir.deadlines.DeadlineMetrics.Expired_PropagationDisabled;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
@@ -64,6 +65,9 @@ public final class Deadlines {
         if (remainingDeadline.isEmpty()) {
             return Optional.empty();
         }
+        if (remainingDeadline.get().disablePropagation()) {
+            return Optional.empty();
+        }
         return Optional.of(remainingDeadline.get().asDuration());
     }
 
@@ -83,9 +87,12 @@ public final class Deadlines {
      * Disables propagation of deadline values any further for the current trace.
      *
      * Callers can use this to short-circuit deadline propagation from the current trace when they are sure that
-     * further operations should not be subject to deadline enforcement. Further calls to {@link #encodeToRequest}
-     * will result in a no-op assuming a deadline has previously be set for this trace (e.g. via a previous call to
-     * {@link #parseFromRequest}).
+     * further operations should not be subject to deadline enforcement.
+     *
+     * Further calls to {@link #encodeToRequest} will result in a no-op assuming a deadline has previously been
+     * set for this trace (e.g. via a previous call to {@link #parseFromRequest}).
+     *
+     * Further calls to {@link #getRemainingDeadline} will return {@link Optional#empty()}.
      */
     public static void disableFurtherDeadlinePropagation() {
         ProvidedDeadline currentState = deadlineState.get();
@@ -188,11 +195,17 @@ public final class Deadlines {
         deadlineState.set(providedDeadline);
     }
 
-    private static void checkExpiration(long deadline, boolean internal, boolean _disablePropagation) {
+    private static void checkExpiration(long deadline, boolean internal, boolean disablePropagation) {
         if (deadline <= 0) {
             // expired
             Expired_Cause cause = internal ? Expired_Cause.INTERNAL : Expired_Cause.EXTERNAL;
-            metrics.expired(cause).mark();
+            Expired_PropagationDisabled propagationDisabled =
+                    disablePropagation ? Expired_PropagationDisabled.TRUE : Expired_PropagationDisabled.FALSE;
+            metrics.expired()
+                    .cause(cause)
+                    .propagationDisabled(propagationDisabled)
+                    .build()
+                    .mark();
             // TODO(blaub): throw exception instead of return
         }
     }

--- a/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
@@ -75,7 +75,25 @@ public final class Deadlines {
         // compute the remaining deadline relative to the current wall clock (may be negative)
         long elapsed = getClockNanoTime() - providedDeadline.wallClockNanos();
         long remaining = providedDeadline.valueNanos() - elapsed;
-        return Optional.of(new RemainingDeadline(remaining, providedDeadline.internal()));
+        return Optional.of(
+                new RemainingDeadline(remaining, providedDeadline.internal(), providedDeadline.disablePropagation()));
+    }
+
+    /**
+     * Disables propagation of deadline values any further for the current trace.
+     *
+     * Callers can use this to short-circuit deadline propagation from the current trace when they are sure that
+     * further operations should not be subject to deadline enforcement. Further calls to {@link #encodeToRequest}
+     * will result in a no-op assuming a deadline has previously be set for this trace (e.g. via a previous call to
+     * {@link #parseFromRequest}).
+     */
+    public static void disableFurtherDeadlinePropagation() {
+        ProvidedDeadline currentState = deadlineState.get();
+        if (currentState != null) {
+            // does not check for expiration
+            deadlineState.set(new ProvidedDeadline(
+                    currentState.valueNanos(), currentState.wallClockNanos(), currentState.internal(), true));
+        }
     }
 
     /**
@@ -100,20 +118,27 @@ public final class Deadlines {
         long proposedDeadlineNanos = proposedDeadline.toNanos();
         if (deadlineFromState.isEmpty()) {
             // use proposedDeadline
-            checkExpiration(proposedDeadlineNanos, false);
+            checkExpiration(proposedDeadlineNanos, false, false);
             adapter.setHeader(
                     request, DeadlinesHttpHeaders.EXPECT_WITHIN, durationToHeaderValue(proposedDeadlineNanos));
         } else {
             // use the minimum of proposedDeadline and the one read from state
             RemainingDeadline stateDeadline = deadlineFromState.get();
             if (proposedDeadlineNanos <= stateDeadline.valueNanos()) {
-                checkExpiration(proposedDeadlineNanos, false);
-                adapter.setHeader(
-                        request, DeadlinesHttpHeaders.EXPECT_WITHIN, durationToHeaderValue(proposedDeadlineNanos));
+                checkExpiration(proposedDeadlineNanos, false, stateDeadline.disablePropagation());
+                if (!stateDeadline.disablePropagation()) {
+                    adapter.setHeader(
+                            request, DeadlinesHttpHeaders.EXPECT_WITHIN, durationToHeaderValue(proposedDeadlineNanos));
+                }
             } else {
-                checkExpiration(stateDeadline.valueNanos(), stateDeadline.internal());
-                adapter.setHeader(
-                        request, DeadlinesHttpHeaders.EXPECT_WITHIN, durationToHeaderValue(stateDeadline.valueNanos()));
+                checkExpiration(
+                        stateDeadline.valueNanos(), stateDeadline.internal(), stateDeadline.disablePropagation());
+                if (!stateDeadline.disablePropagation()) {
+                    adapter.setHeader(
+                            request,
+                            DeadlinesHttpHeaders.EXPECT_WITHIN,
+                            durationToHeaderValue(stateDeadline.valueNanos()));
+                }
             }
         }
     }
@@ -158,12 +183,12 @@ public final class Deadlines {
     }
 
     private static void storeDeadline(long deadline, boolean internal) {
-        checkExpiration(deadline, internal);
-        ProvidedDeadline providedDeadline = new ProvidedDeadline(deadline, getClockNanoTime(), internal);
+        checkExpiration(deadline, internal, false);
+        ProvidedDeadline providedDeadline = new ProvidedDeadline(deadline, getClockNanoTime(), internal, false);
         deadlineState.set(providedDeadline);
     }
 
-    private static void checkExpiration(long deadline, boolean internal) {
+    private static void checkExpiration(long deadline, boolean internal, boolean _disablePropagation) {
         if (deadline <= 0) {
             // expired
             Expired_Cause cause = internal ? Expired_Cause.INTERNAL : Expired_Cause.EXTERNAL;
@@ -256,9 +281,10 @@ public final class Deadlines {
         }
     }
 
-    private record ProvidedDeadline(long valueNanos, long wallClockNanos, boolean internal) {}
+    private record ProvidedDeadline(
+            long valueNanos, long wallClockNanos, boolean internal, boolean disablePropagation) {}
 
-    private record RemainingDeadline(long valueNanos, boolean internal) {
+    private record RemainingDeadline(long valueNanos, boolean internal, boolean disablePropagation) {
         Duration asDuration() {
             return valueNanos <= 0 ? Duration.ZERO : Duration.ofNanos(valueNanos);
         }

--- a/deadlines/src/main/metrics/deadlines-metrics.yml
+++ b/deadlines/src/main/metrics/deadlines-metrics.yml
@@ -18,4 +18,12 @@ namespaces:
                 docs: A deadline expiration was caused due to the inability to meet an 
                       externally provided deadline, such as a server being unable to
                       complete required work before a client-provided deadline elapses.
+          - name: propagationDisabled
+            values:
+              - value: false
+                docs: Deadline propagation was disabled for this trace at the time
+                      the deadline expiration was reached.
+              - value: true
+                docs: Deadline propagation was enabled for this trace at the time
+                      the deadline expiration was reached.
         docs: Marked every time a deadline expiration is reached

--- a/deadlines/src/main/metrics/deadlines-metrics.yml
+++ b/deadlines/src/main/metrics/deadlines-metrics.yml
@@ -21,9 +21,9 @@ namespaces:
           - name: propagationDisabled
             values:
               - value: false
-                docs: Deadline propagation was disabled for this trace at the time
+                docs: Deadline propagation was enabled for this trace at the time
                       the deadline expiration was reached.
               - value: true
-                docs: Deadline propagation was enabled for this trace at the time
+                docs: Deadline propagation was disabled for this trace at the time
                       the deadline expiration was reached.
         docs: Marked every time a deadline expiration is reached

--- a/deadlines/src/main/metrics/deadlines-metrics.yml
+++ b/deadlines/src/main/metrics/deadlines-metrics.yml
@@ -18,12 +18,17 @@ namespaces:
                 docs: A deadline expiration was caused due to the inability to meet an 
                       externally provided deadline, such as a server being unable to
                       complete required work before a client-provided deadline elapses.
-          - name: propagationDisabled
+          - name: intent
+            docs: Describes the intent (or not) to propagate an expired deadline on
+                 further RPC calls.
             values:
-              - value: false
+              - value: propagate
                 docs: Deadline propagation was enabled for this trace at the time
-                      the deadline expiration was reached.
-              - value: true
+                      the deadline expiration was reached. This means that further
+                      RPC calls will still potentially propagate an expired deadline
+                      value.
+              - value: ignore
                 docs: Deadline propagation was disabled for this trace at the time
-                      the deadline expiration was reached.
+                      the deadline expiration was reached. This means that further
+                      RPC calls will not propagate an expired deadline value any more.
         docs: Marked every time a deadline expiration is reached

--- a/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
+++ b/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
@@ -250,6 +250,33 @@ class DeadlinesTest {
     }
 
     @Test
+    public void encode_to_request_noop_when_propagation_disabled() {
+        try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
+            Map<String, String> inboundRequest = new HashMap<>();
+            inboundRequest.put(
+                    DeadlinesHttpHeaders.EXPECT_WITHIN,
+                    Deadlines.durationToHeaderValue(Duration.ofSeconds(2).toNanos()));
+            Deadlines.parseFromRequest(Optional.empty(), inboundRequest, DummyRequestDecoder.INSTANCE);
+
+            Optional<Duration> stateDeadline = Deadlines.getRemainingDeadline();
+            assertThat(stateDeadline).isPresent();
+
+            Deadlines.disableFurtherDeadlinePropagation();
+
+            Map<String, String> outboundRequest = new HashMap<>();
+            Duration providedDeadline = Duration.ofSeconds(1);
+            Deadlines.encodeToRequest(providedDeadline, outboundRequest, DummyRequestEncoder.INSTANCE);
+
+            // even with a provided deadline lower than the one from state, disabling propagation should prevent
+            // further encoding of headers
+            assertThat(outboundRequest).isEmpty();
+
+            // getRemainingDeadline should always return empty now
+            assertThat(Deadlines.getRemainingDeadline()).isEmpty();
+        }
+    }
+
+    @Test
     public void parse_from_request_noop_when_no_header_present() {
         try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
             Map<String, String> request = new HashMap<>();
@@ -322,7 +349,7 @@ class DeadlinesTest {
     }
 
     @Test
-    public void test_encode_to_request_expiration_internal_deadline_2() {
+    public void test_encode_to_request_expiration_internal_deadline() {
         TestClock clock = new TestClock();
         Deadlines.setClock(clock);
         try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
@@ -353,6 +380,54 @@ class DeadlinesTest {
 
             assertThat(internalMeter.getCount()).isGreaterThan(originalInternalValue);
             assertThat(externalMeter.getCount()).isEqualTo(originalExternalValue);
+        }
+    }
+
+    @Test
+    public void disabled_propagation_reports_metrics_on_expiration() {
+        TestClock clock = new TestClock();
+        Deadlines.setClock(clock);
+        try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
+            Map<String, String> request = new HashMap<>();
+            Duration providedDeadline = Duration.ofMillis(1);
+            request.put(
+                    DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE);
+
+            clock.elapsed += 2_000_000;
+
+            Optional<Duration> remaining = Deadlines.getRemainingDeadline();
+            assertThat(remaining).hasValueSatisfying(d -> assertThat(d).isEqualTo(Duration.ZERO));
+
+            DeadlineMetrics metrics = DeadlineMetrics.of(SharedTaggedMetricRegistries.getSingleton());
+            Meter externalMeterWillPropagate = metrics.expired()
+                    .cause(Expired_Cause.EXTERNAL)
+                    .propagationDisabled(Expired_PropagationDisabled.FALSE)
+                    .build();
+            Meter externalMeterWontPropagate = metrics.expired()
+                    .cause(Expired_Cause.EXTERNAL)
+                    .propagationDisabled(Expired_PropagationDisabled.TRUE)
+                    .build();
+            long originalWillPropagateValue = externalMeterWillPropagate.getCount();
+            long originalWontPropagateValue = externalMeterWontPropagate.getCount();
+
+            // first request is allowed to propagate the deadline, make sure the correct meter is marked
+            Map<String, String> outbound1 = new HashMap<>();
+            Deadlines.encodeToRequest(Duration.ofSeconds(10), outbound1, DummyRequestEncoder.INSTANCE);
+            assertThat(externalMeterWillPropagate.getCount()).isGreaterThan(originalWillPropagateValue);
+            assertThat(externalMeterWontPropagate.getCount()).isEqualTo(originalWontPropagateValue);
+
+            originalWillPropagateValue = externalMeterWillPropagate.getCount();
+            originalWontPropagateValue = externalMeterWontPropagate.getCount();
+
+            // and now disable propagation
+            Deadlines.disableFurtherDeadlinePropagation();
+
+            // second request is not allowed to propagate the deadline, make sure the correct meter is marked
+            Map<String, String> outbound2 = new HashMap<>();
+            Deadlines.encodeToRequest(Duration.ofSeconds(10), outbound2, DummyRequestEncoder.INSTANCE);
+            assertThat(externalMeterWontPropagate.getCount()).isGreaterThan(originalWontPropagateValue);
+            assertThat(externalMeterWillPropagate.getCount()).isEqualTo(originalWillPropagateValue);
         }
     }
 

--- a/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
+++ b/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 
 import com.codahale.metrics.Meter;
 import com.palantir.deadlines.DeadlineMetrics.Expired_Cause;
+import com.palantir.deadlines.DeadlineMetrics.Expired_PropagationDisabled;
 import com.palantir.deadlines.Deadlines.RequestDecodingAdapter;
 import com.palantir.deadlines.Deadlines.RequestEncodingAdapter;
 import com.palantir.tracing.CloseableTracer;
@@ -301,8 +302,14 @@ class DeadlinesTest {
             assertThat(remaining).hasValueSatisfying(d -> assertThat(d).isEqualTo(Duration.ZERO));
 
             DeadlineMetrics metrics = DeadlineMetrics.of(SharedTaggedMetricRegistries.getSingleton());
-            Meter externalMeter = metrics.expired(Expired_Cause.EXTERNAL);
-            Meter internalMeter = metrics.expired(Expired_Cause.INTERNAL);
+            Meter externalMeter = metrics.expired()
+                    .cause(Expired_Cause.EXTERNAL)
+                    .propagationDisabled(Expired_PropagationDisabled.FALSE)
+                    .build();
+            Meter internalMeter = metrics.expired()
+                    .cause(Expired_Cause.INTERNAL)
+                    .propagationDisabled(Expired_PropagationDisabled.FALSE)
+                    .build();
             long originalExternalValue = externalMeter.getCount();
             long originalInternalValue = internalMeter.getCount();
 
@@ -330,8 +337,14 @@ class DeadlinesTest {
             assertThat(remaining).hasValueSatisfying(d -> assertThat(d).isEqualTo(Duration.ZERO));
 
             DeadlineMetrics metrics = DeadlineMetrics.of(SharedTaggedMetricRegistries.getSingleton());
-            Meter externalMeter = metrics.expired(Expired_Cause.EXTERNAL);
-            Meter internalMeter = metrics.expired(Expired_Cause.INTERNAL);
+            Meter externalMeter = metrics.expired()
+                    .cause(Expired_Cause.EXTERNAL)
+                    .propagationDisabled(Expired_PropagationDisabled.FALSE)
+                    .build();
+            Meter internalMeter = metrics.expired()
+                    .cause(Expired_Cause.INTERNAL)
+                    .propagationDisabled(Expired_PropagationDisabled.FALSE)
+                    .build();
             long originalExternalValue = externalMeter.getCount();
             long originalInternalValue = internalMeter.getCount();
 

--- a/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
+++ b/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 
 import com.codahale.metrics.Meter;
 import com.palantir.deadlines.DeadlineMetrics.Expired_Cause;
-import com.palantir.deadlines.DeadlineMetrics.Expired_PropagationDisabled;
+import com.palantir.deadlines.DeadlineMetrics.Expired_Intent;
 import com.palantir.deadlines.Deadlines.RequestDecodingAdapter;
 import com.palantir.deadlines.Deadlines.RequestEncodingAdapter;
 import com.palantir.tracing.CloseableTracer;
@@ -331,11 +331,11 @@ class DeadlinesTest {
             DeadlineMetrics metrics = DeadlineMetrics.of(SharedTaggedMetricRegistries.getSingleton());
             Meter externalMeter = metrics.expired()
                     .cause(Expired_Cause.EXTERNAL)
-                    .propagationDisabled(Expired_PropagationDisabled.FALSE)
+                    .intent(Expired_Intent.PROPAGATE)
                     .build();
             Meter internalMeter = metrics.expired()
                     .cause(Expired_Cause.INTERNAL)
-                    .propagationDisabled(Expired_PropagationDisabled.FALSE)
+                    .intent(Expired_Intent.PROPAGATE)
                     .build();
             long originalExternalValue = externalMeter.getCount();
             long originalInternalValue = internalMeter.getCount();
@@ -366,11 +366,11 @@ class DeadlinesTest {
             DeadlineMetrics metrics = DeadlineMetrics.of(SharedTaggedMetricRegistries.getSingleton());
             Meter externalMeter = metrics.expired()
                     .cause(Expired_Cause.EXTERNAL)
-                    .propagationDisabled(Expired_PropagationDisabled.FALSE)
+                    .intent(Expired_Intent.PROPAGATE)
                     .build();
             Meter internalMeter = metrics.expired()
                     .cause(Expired_Cause.INTERNAL)
-                    .propagationDisabled(Expired_PropagationDisabled.FALSE)
+                    .intent(Expired_Intent.PROPAGATE)
                     .build();
             long originalExternalValue = externalMeter.getCount();
             long originalInternalValue = internalMeter.getCount();
@@ -402,11 +402,11 @@ class DeadlinesTest {
             DeadlineMetrics metrics = DeadlineMetrics.of(SharedTaggedMetricRegistries.getSingleton());
             Meter externalMeterWillPropagate = metrics.expired()
                     .cause(Expired_Cause.EXTERNAL)
-                    .propagationDisabled(Expired_PropagationDisabled.FALSE)
+                    .intent(Expired_Intent.PROPAGATE)
                     .build();
             Meter externalMeterWontPropagate = metrics.expired()
                     .cause(Expired_Cause.EXTERNAL)
-                    .propagationDisabled(Expired_PropagationDisabled.TRUE)
+                    .intent(Expired_Intent.IGNORE)
                     .build();
             long originalWillPropagateValue = externalMeterWillPropagate.getCount();
             long originalWontPropagateValue = externalMeterWontPropagate.getCount();


### PR DESCRIPTION
Adds a method to disable further propagation of deadline values via the `Deadlines.encodeToRequest` method. The use case for this is to prevent RPC call stacks from continuing to send `Expect-Within: 0` after a deadline has expired, which can lead to quite a bit of noise in reported metrics and logging.

Callers can use `Deadlines.disableFurtherDeadlinePropagation()` to instruct the library to ignore the internal deadline state on further calls to `encodeToRequest`. Future calls to `Deadlines.getRemainingDeadline()` will return `Optional.empty()`.

Callers are expected to use this only when they can ensure that further operations should not be subject to deadline enforcement. A primary use case for this is for requests that spin off background work which may continue to make requests, even when the original request handler has terminated. In those instances, callers _may_ wish to stop enforcing the deadline as it is quite possible a background task will make a request well into the future after the original deadline is expired, and the semantics of that are somewhat of a judgement call. Adding this flag will allow callers to control the fate of such future requests with respect to deadline enforcement.

This change adds the following:
- the `Deadlines.disableFurtherDeadlinePropagation()` method, which alters the internal state of the current deadline within the TraceLocal, setting a flag to disable propagation
- changes the internal state structures to track deadline propagation via a boolean
- adds an `intent` tag to the deadline expiration meter metric reported via this library; this tag will be set to `ignore` in scenarios where `encodeToRequest` was called after `disableFurtherDeadlinePropagation` was called, and `propagate` otherwise

==COMMIT_MSG==
add ability to disable deadline propagation
==COMMIT_MSG==
