### PR TITLE
ProvidedDeadline needn't declare alreadyExpired

### DIFF
--- a/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
@@ -79,8 +79,11 @@ public final class Deadlines {
         // compute the remaining deadline relative to the current wall clock (may be negative)
         long elapsed = getClockNanoTime() - providedDeadline.wallClockNanos();
         long remaining = providedDeadline.valueNanos() - elapsed;
-        return Optional.of(
-                new RemainingDeadline(remaining, providedDeadline.internal(), providedDeadline.disablePropagation()));
+        return Optional.of(new RemainingDeadline(
+                remaining,
+                providedDeadline.internal(),
+                providedDeadline.disablePropagation(),
+                providedDeadline.alreadyExpired()));
     }
 
     /**
@@ -99,7 +102,11 @@ public final class Deadlines {
         if (currentState != null) {
             // does not check for expiration
             deadlineState.set(new ProvidedDeadline(
-                    currentState.valueNanos(), currentState.wallClockNanos(), currentState.internal(), true));
+                    currentState.valueNanos(),
+                    currentState.wallClockNanos(),
+                    currentState.internal(),
+                    true,
+                    currentState.alreadyExpired()));
         }
     }
 
@@ -125,21 +132,29 @@ public final class Deadlines {
         long proposedDeadlineNanos = proposedDeadline.toNanos();
         if (deadlineFromState.isEmpty()) {
             // use proposedDeadline
-            checkExpiration(proposedDeadlineNanos, false, false);
+            checkExpiration(proposedDeadlineNanos, false, false, false);
             adapter.setHeader(
                     request, DeadlinesHttpHeaders.EXPECT_WITHIN, durationToHeaderValue(proposedDeadlineNanos));
         } else {
             // use the minimum of proposedDeadline and the one read from state
             RemainingDeadline stateDeadline = deadlineFromState.get();
             if (proposedDeadlineNanos <= stateDeadline.valueNanos()) {
-                checkExpiration(proposedDeadlineNanos, false, stateDeadline.disablePropagation());
+                boolean proposedDeadlineAlreadyExpired = proposedDeadline.isNegative() || proposedDeadline.isZero();
+                checkExpiration(
+                        proposedDeadlineNanos,
+                        false,
+                        stateDeadline.disablePropagation(),
+                        proposedDeadlineAlreadyExpired);
                 if (!stateDeadline.disablePropagation()) {
                     adapter.setHeader(
                             request, DeadlinesHttpHeaders.EXPECT_WITHIN, durationToHeaderValue(proposedDeadlineNanos));
                 }
             } else {
                 checkExpiration(
-                        stateDeadline.valueNanos(), stateDeadline.internal(), stateDeadline.disablePropagation());
+                        stateDeadline.valueNanos(),
+                        stateDeadline.internal(),
+                        stateDeadline.disablePropagation(),
+                        stateDeadline.alreadyExpired());
                 if (!stateDeadline.disablePropagation()) {
                     adapter.setHeader(
                             request,
@@ -190,16 +205,24 @@ public final class Deadlines {
     }
 
     private static void storeDeadline(long deadline, boolean internal) {
-        checkExpiration(deadline, internal, false);
-        ProvidedDeadline providedDeadline = new ProvidedDeadline(deadline, getClockNanoTime(), internal, false);
+        boolean alreadyExpired = deadline <= 0;
+        checkExpiration(deadline, internal, false, alreadyExpired);
+        ProvidedDeadline providedDeadline =
+                new ProvidedDeadline(deadline, getClockNanoTime(), internal, false, alreadyExpired);
         deadlineState.set(providedDeadline);
     }
 
-    private static void checkExpiration(long deadline, boolean internal, boolean disablePropagation) {
+    private static void checkExpiration(
+            long deadline, boolean internal, boolean disablePropagation, boolean alreadyExpired) {
         if (deadline <= 0) {
             // expired
             Expired_Cause cause = internal ? Expired_Cause.INTERNAL : Expired_Cause.EXTERNAL;
-            Expired_Intent intent = disablePropagation ? Expired_Intent.IGNORE : Expired_Intent.PROPAGATE;
+            Expired_Intent intent = Expired_Intent.PROPAGATE;
+            if (disablePropagation) {
+                intent = Expired_Intent.IGNORE;
+            } else if (alreadyExpired) {
+                intent = Expired_Intent.PROPAGATE_ALREADY_EXPIRED;
+            }
             metrics.expired().cause(cause).intent(intent).build().mark();
             // TODO(blaub): throw exception instead of return
         }
@@ -290,9 +313,14 @@ public final class Deadlines {
     }
 
     private record ProvidedDeadline(
-            long valueNanos, long wallClockNanos, boolean internal, boolean disablePropagation) {}
+            long valueNanos,
+            long wallClockNanos,
+            boolean internal,
+            boolean disablePropagation,
+            boolean alreadyExpired) {}
 
-    private record RemainingDeadline(long valueNanos, boolean internal, boolean disablePropagation) {
+    private record RemainingDeadline(
+            long valueNanos, boolean internal, boolean disablePropagation, boolean alreadyExpired) {
         Duration asDuration() {
             return valueNanos <= 0 ? Duration.ZERO : Duration.ofNanos(valueNanos);
         }

--- a/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
@@ -102,11 +102,7 @@ public final class Deadlines {
         if (currentState != null) {
             // does not check for expiration
             deadlineState.set(new ProvidedDeadline(
-                    currentState.valueNanos(),
-                    currentState.wallClockNanos(),
-                    currentState.internal(),
-                    true,
-                    currentState.alreadyExpired()));
+                    currentState.valueNanos(), currentState.wallClockNanos(), currentState.internal(), true));
         }
     }
 
@@ -205,10 +201,12 @@ public final class Deadlines {
     }
 
     private static void storeDeadline(long deadline, boolean internal) {
-        boolean alreadyExpired = deadline <= 0;
-        checkExpiration(deadline, internal, false, alreadyExpired);
-        ProvidedDeadline providedDeadline =
-                new ProvidedDeadline(deadline, getClockNanoTime(), internal, false, alreadyExpired);
+        ProvidedDeadline providedDeadline = new ProvidedDeadline(deadline, getClockNanoTime(), internal, false);
+        checkExpiration(
+                providedDeadline.valueNanos(),
+                providedDeadline.internal(),
+                providedDeadline.disablePropagation(),
+                providedDeadline.alreadyExpired());
         deadlineState.set(providedDeadline);
     }
 
@@ -313,11 +311,12 @@ public final class Deadlines {
     }
 
     private record ProvidedDeadline(
-            long valueNanos,
-            long wallClockNanos,
-            boolean internal,
-            boolean disablePropagation,
-            boolean alreadyExpired) {}
+            long valueNanos, long wallClockNanos, boolean internal, boolean disablePropagation) {
+
+        boolean alreadyExpired() {
+            return valueNanos <= 0;
+        }
+    }
 
     private record RemainingDeadline(
             long valueNanos, boolean internal, boolean disablePropagation, boolean alreadyExpired) {

--- a/deadlines/src/main/metrics/deadlines-metrics.yml
+++ b/deadlines/src/main/metrics/deadlines-metrics.yml
@@ -27,6 +27,9 @@ namespaces:
                       the deadline expiration was reached. This means that further
                       RPC calls will still potentially propagate an expired deadline
                       value.
+              - value: propagate-already-expired
+                docs: Deadline propagation was enabled for this trace, but the deadline
+                      had already expired by the time it was first received.
               - value: ignore
                 docs: Deadline propagation was disabled for this trace at the time
                       the deadline expiration was reached. This means that further

--- a/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
+++ b/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
@@ -24,7 +24,9 @@ import com.palantir.deadlines.DeadlineMetrics.Expired_Cause;
 import com.palantir.deadlines.DeadlineMetrics.Expired_Intent;
 import com.palantir.deadlines.Deadlines.RequestDecodingAdapter;
 import com.palantir.deadlines.Deadlines.RequestEncodingAdapter;
+import com.palantir.tracing.CloseableSpan;
 import com.palantir.tracing.CloseableTracer;
+import com.palantir.tracing.DetachedSpan;
 import com.palantir.tritium.metrics.registry.SharedTaggedMetricRegistries;
 import java.time.Duration;
 import java.util.HashMap;
@@ -428,6 +430,72 @@ class DeadlinesTest {
             Deadlines.encodeToRequest(Duration.ofSeconds(10), outbound2, DummyRequestEncoder.INSTANCE);
             assertThat(externalMeterWontPropagate.getCount()).isGreaterThan(originalWontPropagateValue);
             assertThat(externalMeterWillPropagate.getCount()).isEqualTo(originalWillPropagateValue);
+        }
+    }
+
+    @Test
+    public void multihop_expired_received_deadline_marks_propagate_already_expired_meter() {
+        TestClock clock = new TestClock();
+        Deadlines.setClock(clock);
+
+        DetachedSpan server1Span = DetachedSpan.start("server1");
+        DetachedSpan server2Span = DetachedSpan.start("server2");
+
+        try (CloseableSpan ignored = server1Span.attach()) {
+            DeadlineMetrics metrics = DeadlineMetrics.of(SharedTaggedMetricRegistries.getSingleton());
+            Meter expiredMeterPropagateIntent = metrics.expired()
+                    .cause(Expired_Cause.EXTERNAL)
+                    .intent(Expired_Intent.PROPAGATE)
+                    .build();
+            Meter expiredMeterPropagateAlreadyExpiredIntent = metrics.expired()
+                    .cause(Expired_Cause.EXTERNAL)
+                    .intent(Expired_Intent.PROPAGATE_ALREADY_EXPIRED)
+                    .build();
+
+            // the first hop receives a valid, non-zero deadline on the wire
+            Map<String, String> request = new HashMap<>();
+            Duration providedDeadline = Duration.ofMillis(1);
+            request.put(
+                    DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE);
+            // nothing yet...
+            assertThat(expiredMeterPropagateIntent.getCount()).isZero();
+            assertThat(expiredMeterPropagateAlreadyExpiredIntent.getCount()).isZero();
+
+            // force expiration within the first hop
+            clock.elapsed += 2_000_000;
+
+            long expiredMeterPropagateIntentValue = expiredMeterPropagateIntent.getCount();
+            long expiredMeterPropagateAlreadyExpiredIntentValue = expiredMeterPropagateAlreadyExpiredIntent.getCount();
+
+            Map<String, String> outbound1 = new HashMap<>();
+            Deadlines.encodeToRequest(Duration.ofSeconds(10), outbound1, DummyRequestEncoder.INSTANCE);
+
+            // this hop marks the meter with the "propagate" intent, as the expiration happened here
+            assertThat(outbound1.get(DeadlinesHttpHeaders.EXPECT_WITHIN))
+                    .isNotNull()
+                    .isEqualTo("0");
+            assertThat(expiredMeterPropagateIntent.getCount()).isGreaterThan(expiredMeterPropagateIntentValue);
+            assertThat(expiredMeterPropagateAlreadyExpiredIntent.getCount()).isZero();
+
+            // next hop parses a zero deadline
+            try (CloseableSpan ignored2 = server2Span.attach()) {
+                expiredMeterPropagateIntentValue = expiredMeterPropagateIntent.getCount();
+                Deadlines.parseFromRequest(Optional.empty(), outbound1, DummyRequestDecoder.INSTANCE);
+                // this hop marks the meter with the "propagate-already-expired" intent
+                assertThat(expiredMeterPropagateAlreadyExpiredIntent.getCount())
+                        .isGreaterThan(expiredMeterPropagateAlreadyExpiredIntentValue);
+                // meter with the "propagate" intent is unchanged
+                assertThat(expiredMeterPropagateIntent.getCount()).isEqualTo(expiredMeterPropagateIntentValue);
+
+                // sending another request when the deadline has already expired should also
+                // mark the meter with the "propagate-already-expired" intent
+                expiredMeterPropagateAlreadyExpiredIntentValue = expiredMeterPropagateAlreadyExpiredIntent.getCount();
+                Map<String, String> outbound2 = new HashMap<>();
+                Deadlines.encodeToRequest(Duration.ofSeconds(10), outbound2, DummyRequestEncoder.INSTANCE);
+                assertThat(expiredMeterPropagateAlreadyExpiredIntent.getCount())
+                        .isGreaterThan(expiredMeterPropagateAlreadyExpiredIntentValue);
+            }
         }
     }
 


### PR DESCRIPTION
I think we could simplify out the `RemainingDeadline` type entirely, reducing allocation required for deadlines operations. Given a snapshot from the clock, and the `ProvidedDeadline`, we should have everything we need.