### PR TITLE
Redundant calls to disablePropagation are a no-op

### DIFF
--- a/changelog/@unreleased/pr-48.v2.yml
+++ b/changelog/@unreleased/pr-48.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Redundant calls to disablePropagation are a no-op
+  links:
+  - https://github.com/palantir/deadlines-java/pull/48

--- a/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
@@ -85,7 +85,7 @@ public final class Deadlines {
      */
     public static void disableFurtherDeadlinePropagation() {
         ProvidedDeadline currentState = deadlineState.get();
-        if (currentState != null) {
+        if (currentState != null && !currentState.disablePropagation()) {
             // does not check for expiration
             deadlineState.set(new ProvidedDeadline(
                     currentState.valueNanos(), currentState.wallClockNanos(), currentState.internal(), true));


### PR DESCRIPTION
No change in behavior, this just avoids an allocation in the case the method is called multiple times for the same trace