### PR TITLE
dont report expired metrics when storing deadlines (take 2)

### DIFF
--- a/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
@@ -188,11 +188,6 @@ public final class Deadlines {
 
     private static void storeDeadline(long deadline, boolean internal) {
         ProvidedDeadline providedDeadline = new ProvidedDeadline(deadline, getClockNanoTime(), internal, false);
-        checkExpiration(
-                providedDeadline.valueNanos(),
-                providedDeadline.internal(),
-                providedDeadline.disablePropagation(),
-                providedDeadline.alreadyExpired());
         deadlineState.set(providedDeadline);
     }
 

--- a/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
+++ b/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
@@ -482,19 +482,15 @@ class DeadlinesTest {
             try (CloseableSpan ignored2 = server2Span.attach()) {
                 expiredMeterPropagateIntentValue = expiredMeterPropagateIntent.getCount();
                 Deadlines.parseFromRequest(Optional.empty(), outbound1, DummyRequestDecoder.INSTANCE);
-                // this hop marks the meter with the "propagate-already-expired" intent
-                assertThat(expiredMeterPropagateAlreadyExpiredIntent.getCount())
-                        .isGreaterThan(expiredMeterPropagateAlreadyExpiredIntentValue);
-                // meter with the "propagate" intent is unchanged
-                assertThat(expiredMeterPropagateIntent.getCount()).isEqualTo(expiredMeterPropagateIntentValue);
-
-                // sending another request when the deadline has already expired should also
+                // sending another request when the deadline has already expired should
                 // mark the meter with the "propagate-already-expired" intent
                 expiredMeterPropagateAlreadyExpiredIntentValue = expiredMeterPropagateAlreadyExpiredIntent.getCount();
                 Map<String, String> outbound2 = new HashMap<>();
                 Deadlines.encodeToRequest(Duration.ofSeconds(10), outbound2, DummyRequestEncoder.INSTANCE);
                 assertThat(expiredMeterPropagateAlreadyExpiredIntent.getCount())
                         .isGreaterThan(expiredMeterPropagateAlreadyExpiredIntentValue);
+                // meter with the "propagate" intent is unchanged
+                assertThat(expiredMeterPropagateIntent.getCount()).isEqualTo(expiredMeterPropagateIntentValue);
             }
         }
     }


### PR DESCRIPTION
this was originally removed in #44 but looks to have gotten undone by a bad merge conflict resolution.