### PR TITLE
allow negative deadlines returned by getRemainingDeadline

### DIFF
--- a/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
@@ -53,11 +53,11 @@ public final class Deadlines {
      *
      * Queries the current deadline state from a TraceLocal, and returns a {@link Duration} for the
      * amount of time remaining towards that deadline. If the deadline has already expired, then
-     * {@link Duration#ZERO} is returned.
+     * a duration less than or equal to zero is returned.
      *
      * If no deadline state has been set for the current trace, return an empty Optional.
      *
-     * @return the remaining deadline time for the current trace, or {@link Duration#ZERO} if the deadline
+     * @return the remaining deadline time for the current trace, which may be negative if the deadline
      * has expired, or {@link Optional#empty()} if no such deadline state exists.
      */
     public static Optional<Duration> getRemainingDeadline() {
@@ -69,7 +69,7 @@ public final class Deadlines {
             return Optional.empty();
         }
         long remaining = stateDeadline.remainingNanos(getClockNanoTime());
-        return Optional.of(remaining <= 0 ? Duration.ZERO : Duration.ofNanos(remaining));
+        return Optional.of(Duration.ofNanos(remaining));
     }
 
     /**

--- a/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
+++ b/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
@@ -310,7 +310,7 @@ class DeadlinesTest {
             clock.elapsed += 2_000_000;
 
             Optional<Duration> remaining = Deadlines.getRemainingDeadline();
-            assertThat(remaining).hasValueSatisfying(d -> assertThat(d).isEqualTo(Duration.ZERO));
+            assertThat(remaining).hasValueSatisfying(d -> assertThat(d).isLessThanOrEqualTo(Duration.ZERO));
         }
     }
 
@@ -328,7 +328,7 @@ class DeadlinesTest {
             clock.elapsed += 2_000_000;
 
             Optional<Duration> remaining = Deadlines.getRemainingDeadline();
-            assertThat(remaining).hasValueSatisfying(d -> assertThat(d).isEqualTo(Duration.ZERO));
+            assertThat(remaining).hasValueSatisfying(d -> assertThat(d).isLessThanOrEqualTo(Duration.ZERO));
 
             DeadlineMetrics metrics = DeadlineMetrics.of(SharedTaggedMetricRegistries.getSingleton());
             Meter externalMeter = metrics.expired()
@@ -363,7 +363,7 @@ class DeadlinesTest {
 
             clock.elapsed += 2_000_000;
             Optional<Duration> remaining = Deadlines.getRemainingDeadline();
-            assertThat(remaining).hasValueSatisfying(d -> assertThat(d).isEqualTo(Duration.ZERO));
+            assertThat(remaining).hasValueSatisfying(d -> assertThat(d).isLessThanOrEqualTo(Duration.ZERO));
 
             DeadlineMetrics metrics = DeadlineMetrics.of(SharedTaggedMetricRegistries.getSingleton());
             Meter externalMeter = metrics.expired()
@@ -399,7 +399,7 @@ class DeadlinesTest {
             clock.elapsed += 2_000_000;
 
             Optional<Duration> remaining = Deadlines.getRemainingDeadline();
-            assertThat(remaining).hasValueSatisfying(d -> assertThat(d).isEqualTo(Duration.ZERO));
+            assertThat(remaining).hasValueSatisfying(d -> assertThat(d).isLessThanOrEqualTo(Duration.ZERO));
 
             DeadlineMetrics metrics = DeadlineMetrics.of(SharedTaggedMetricRegistries.getSingleton());
             Meter externalMeterWillPropagate = metrics.expired()


### PR DESCRIPTION
Previously we always returned Duration.ZERO if the deadline had expired. This is straightforward and keeps some detail hidden from consumers, at the expense of some flexibility.

With this change, just return the raw remaining deadline value as a Duration, which may be less than zero. This allows consumers the flexibility to report observability metrics on deadline expiration (for instance, they can know how far past a deadline some call chain has gone which may be of interest in debugging).