### PR TITLE
add feature flag for deadline enforcement

### DIFF
--- a/changelog/@unreleased/pr-83.v2.yml
+++ b/changelog/@unreleased/pr-83.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: add feature flag for deadline enforcement
+  links:
+  - https://github.com/palantir/deadlines-java/pull/83

--- a/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
@@ -130,6 +130,7 @@ public final class Deadlines {
                     false);
             adapter.setHeader(
                     request, DeadlinesHttpHeaders.EXPECT_WITHIN, durationToHeaderValue(proposedDeadlineNanos));
+            adapter.setHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "false");
         } else {
             // use the minimum of proposedDeadline and the one read from state
             long remainingStateDeadlineNanos = stateDeadline.remainingNanos(getClockNanoTime());
@@ -145,9 +146,7 @@ public final class Deadlines {
                 if (!stateDeadline.disablePropagation()) {
                     adapter.setHeader(
                             request, DeadlinesHttpHeaders.EXPECT_WITHIN, durationToHeaderValue(proposedDeadlineNanos));
-                    if (enforced) {
-                        adapter.setHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "true");
-                    }
+                    adapter.setHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, Boolean.toString(enforced));
                 }
             } else {
                 checkExpiration(
@@ -161,12 +160,51 @@ public final class Deadlines {
                             request,
                             DeadlinesHttpHeaders.EXPECT_WITHIN,
                             durationToHeaderValue(remainingStateDeadlineNanos));
-                    if (enforced) {
-                        adapter.setHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "true");
-                    }
+                    adapter.setHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, Boolean.toString(enforced));
                 }
             }
         }
+    }
+
+    /**
+     * Selects the enforcement strategy when parsing a deadline value from a request.
+     *
+     * Enforcement controls whether this node should enforce expirations when they happen in a future call
+     * to {@link #encodeToRequest} for the current trace. Enabling enforcement means that a {@link DeadlineExpiredException}
+     * will be thrown when a deadline is detected to have expired, and that an enforcement flag will be propagated
+     * when encoding a deadline for a new outbound request.
+     *
+     * There are 3 possible states (described below) to control enforcement; they determine whether the current node
+     * will enforce deadline expirations here, and whether an enforcement flag may be added to future outbound requests;
+     * or whether deadline expirations will be ignored and the enforcement flag not propagated further.
+     */
+    public enum Enforcement {
+        /**
+         * ENFORCED means that future calls to {@link #encodeToRequest} will throw an exception if the deadline has
+         * expired, and also append an {@link DeadlinesHttpHeaders#EXPECT_WITHIN_ENFORCED} header
+         * when encoding future deadlines from the current trace to request enforcement from downstream nodes as well.
+         */
+        ENFORCED,
+
+        /**
+         * ENFORCED_IF_REQUESTED means that future calls to {@link #encodeToRequest} will throw an exception if the
+         * deadline has expired, but only if enforcement was requested at the time we parsed a deadline value from
+         * a request header (e.g. if {@link #parseFromRequest} received an
+         * {@link DeadlinesHttpHeaders#EXPECT_WITHIN_ENFORCED} header set to `true`). Otherwise, no deadline expiration
+         * enforcement will happen at this node, and we propagate an {@link DeadlinesHttpHeaders#EXPECT_WITHIN_ENFORCED}
+         * header set to `false` so that downstream nodes do not enforce the deadline either.
+         */
+        ENFORCED_IF_REQUESTED,
+
+        /**
+         * IGNORED means that deadline expiration will be ignored at this node, and ALL downstream nodes, regardless
+         * of whether an {@link DeadlinesHttpHeaders#EXPECT_WITHIN_ENFORCED} header was received with the value
+         * set to `true`. Future calls to {@link #encodeToRequest} will not throw an exception if the deadline has
+         * expired, and will set add a {@link DeadlinesHttpHeaders#EXPECT_WITHIN_ENFORCED} header on the request to
+         * `false`. This effectively terminates deadline enforcement at this node and causes downstream nodes to
+         * ignore further enforcement for this trace, regardless of their configured enforcement state.
+         */
+        IGNORED
     }
 
     /**
@@ -193,30 +231,58 @@ public final class Deadlines {
      * lower than the one parsed from a request header
      * @param request the request object to read the deadline value from
      * @param adapter a {@link RequestDecodingAdapter} that handles reading the header value from the request object
-     * @param internalEnforced whether this deadline should be enforced at this hop (and all downstream receivers)
+     * @param enforcement configures enforcement strategy (see {@link Enforcement})
      */
     public static <T> void parseFromRequest(
             Optional<Duration> internalDeadline,
             T request,
             RequestDecodingAdapter<? super T> adapter,
-            boolean internalEnforced) {
+            Enforcement enforcement) {
         Long headerDeadline =
                 tryParseSecondsToNanoseconds(adapter.maybeFirstHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN));
-        boolean enforced = internalEnforced;
-        if (!enforced) {
+
+        // check enforcement
+        // if enforcement was explicitly disabled via `Expect-Within-Enforced: false`, then we honor that
+        boolean enforced;
+        if (enforcement == Enforcement.IGNORED) {
+            enforced = false;
+        } else {
+            // check for the `Expect-Within-Enforced` flag in a header
+            // possible outcomes:
+            //   - the header is not present and enforcement == ENFORCED => enforced=true
+            //   - the header is not present and enforcement == ENFORCED_IF_REQUESTED => enforced=false
+            //   - the header is present and the value is "true" => enforced=true
+            //   - the header is present and the value is "false" => enforced=false
+            //       (the rationale for this is that even if local enforcement was requested, if an upstream hop
+            //       requested that it _not_ be enforced then we will honor that instead)
+            //   - the header is present and the value is something else => enforced=(enforcement == ENFORCED)
+            //       (the rationale for this is that if we received a bogus value, we should just make a local decision)
+            //   - the header is present, but the `Expect-Within` header is absent => enforced=(enforcement == ENFORCED)
+            //       (the rationale for this is that we are selecting our own deadline, even though we received an
+            //       enforcement flag, so we should make a local decision)
             String headerEnforced = adapter.maybeFirstHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED);
-            enforced = headerEnforced != null && headerEnforced.equalsIgnoreCase("true");
+            if (headerEnforced == null) {
+                enforced = enforcement == Enforcement.ENFORCED;
+            } else {
+                if (headerDeadline == null) {
+                    enforced = enforcement == Enforcement.ENFORCED;
+                } else {
+                    if (headerEnforced.equalsIgnoreCase("true")) {
+                        enforced = true;
+                    } else if (headerEnforced.equalsIgnoreCase("false")) {
+                        enforced = false;
+                    } else {
+                        enforced = enforcement == Enforcement.ENFORCED;
+                    }
+                }
+            }
         }
         if (headerDeadline != null && internalDeadline.isEmpty()) {
             // use the deadline parsed from a header, which is considered external
             storeDeadline(headerDeadline, false, enforced);
         } else if (headerDeadline == null && internalDeadline.isPresent()) {
             // use the deadline provided to this method, which is considered internal
-            storeDeadline(
-                    internalDeadline.get().toNanos(),
-                    true,
-                    // avoid scenarios where Expect-Within-Enforced is present, but Expect-Within is absent
-                    internalEnforced);
+            storeDeadline(internalDeadline.get().toNanos(), true, enforced);
         } else if (headerDeadline != null) {
             // both present, so use the one that's lower
             long internalDeadlineValue = internalDeadline.get().toNanos();
@@ -233,7 +299,8 @@ public final class Deadlines {
     @Deprecated
     public static <T> void parseFromRequest(
             Optional<Duration> internalDeadline, T request, RequestDecodingAdapter<? super T> adapter) {
-        parseFromRequest(internalDeadline, request, adapter, false);
+        // by default use IGNORED, which matches behavior of consumers on older versions which have no enforcement
+        parseFromRequest(internalDeadline, request, adapter, Enforcement.IGNORED);
     }
 
     private static void storeDeadline(long deadline, boolean internal, boolean enforced) {

--- a/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
@@ -248,6 +248,7 @@ public final class Deadlines {
      * @param adapter a {@link RequestDecodingAdapter} that handles reading the header value from the request object
      * @param enforcement configures enforcement strategy (see {@link Enforcement})
      */
+    @SuppressWarnings("CyclomaticComplexity")
     public static <T> void parseFromRequest(
             Optional<Duration> internalDeadline,
             T request,

--- a/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
@@ -318,8 +318,9 @@ public final class Deadlines {
     @Deprecated
     public static <T> void parseFromRequest(
             Optional<Duration> internalDeadline, T request, RequestDecodingAdapter<? super T> adapter) {
-        // by default use DISABLED, which matches behavior of consumers on older versions which have no enforcement
-        parseFromRequest(internalDeadline, request, adapter, Enforcement.DISABLED);
+        // by default use ENFORCED_IF_REQUESTED, which matches behavior of consumers on older versions which have no
+        // enforcement
+        parseFromRequest(internalDeadline, request, adapter, Enforcement.ENFORCED_IF_REQUESTED);
     }
 
     private static void storeDeadline(long deadline, boolean internal, OutboundEnforcement enforcement) {

--- a/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
@@ -229,12 +229,13 @@ public final class Deadlines {
         // check for the `Expect-Within-Enforced` flag in a header and set the outbound enforcement state
         // accordingly
         // possible outcomes:
-        //   - the header is not present => enforcement == ENFORCE ? ENFORCE : DEFER
+        // possible outcomes:
+        //   - the enforcementStrategy == DISABLED => DISABLED
+        //   - the header is not present => enforcementStrategy == ENFORCE ? ENFORCE : DEFER
+        //   - the header is present but the `Expect-Within` header is absent => enforcementStrategy == ENFORCED ? ENFORCE :  DEFER
         //   - the header is present and the value is "true" => ENFORCE
         //   - the header is present and the value is "false" => DISABLE
-        //   - the header is present and the value is something else => enforcement == ENFORCED ? ENFORCE : DEFER
-        //   - the header is present but the `Expect-Within` header is absent => enforcement == ENFORCED ? ENFORCE :
-        // DEFER
+        //   - the header is present and the value is something else => enforcementStrategy == ENFORCED ? ENFORCE : DEFER
         return switch (enforcementStrategy) {
             case DISABLE -> Enforcement.DISABLE;
             case ENFORCE -> {

--- a/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
@@ -190,6 +190,10 @@ public final class Deadlines {
          * expired, and also append an {@link DeadlinesHttpHeaders#EXPECT_WITHIN_ENFORCED} header with the value set
          * to "true" when encoding future deadlines from the current trace to request enforcement from downstream
          * nodes as well.
+         *
+         * Note that calls to {@link #parseFromRequest} that receive an explicit {@link DeadlinesHttpHeaders#EXPECT_WITHIN_ENFORCED}
+         * header with a value set to "false" will still override this to disable enforcement. This is intentional
+         * to allow upstream nodes to short-circuit deadline enforcement if necessary.
          */
         ENFORCE,
 
@@ -224,14 +228,13 @@ public final class Deadlines {
      * {@link #getRemainingDeadline()}} from threads participating in the current trace. The deadline value
      * is read from a {@link DeadlinesHttpHeaders#EXPECT_WITHIN} header on the request object.
      *
-     * Enforcement of the deadline is enabled in onw of two ways:
-     *   - Callers can set the "internalEnforced" parameter on this method to true.
-     *   - If an "Expect-Within-Enforced" header is present in the request with a value of "true",
-     *     it will enable enforcement.
-     * If either of those conditions are met, the deadline state stored in the TraceLocal will additionally
-     * set an enforcement flag. This will indicate to future calls to {@link #encodeToRequest} that it should check
-     * for and enforce expiration. It also causes those calls to further propagate an "Expect-Within-Enforced" header,
-     * so that downstream receivers will also be required to enforce the deadline expiration.
+     * Enforcement of the deadline is controlled in the following way:
+     *   - If the "enforcementStrategy" parameter is set to {@link Enforcement#DISABLE}, then it is not enforced.
+     *   - If the "enforcementStrategy" parameter is set to {@link Enforcement#DEFER}, then the deadline is enforced
+     *     only if a {@link DeadlinesHttpHeaders#EXPECT_WITHIN_ENFORCED} header is parsed with a value of "true"
+     *   - If the "enforcementStrategy" parameter is set to {@link Enforcement#ENFORCE}, then the deadline is enforced
+     *   - If a {@link DeadlinesHttpHeaders#EXPECT_WITHIN_ENFORCED} header is parsed with a value of "false", then
+     *     the deadline is not enforced and the the value of "enforcementStrategy" is ignored
      *
      * This function has side-effects on the internal deadline state stored in a TraceLocal; the state is
      * set (or overwritten) based on the value of the deadline parsed from request headers.
@@ -240,20 +243,20 @@ public final class Deadlines {
      * lower than the one parsed from a request header
      * @param request the request object to read the deadline value from
      * @param adapter a {@link RequestDecodingAdapter} that handles reading the header value from the request object
-     * @param localEnforcement configures enforcement strategy (see {@link Enforcement})
+     * @param enforcementStrategy configures enforcement strategy (see {@link Enforcement})
      */
     @SuppressWarnings("CyclomaticComplexity")
     public static <T> void parseFromRequest(
             Optional<Duration> internalDeadline,
             T request,
             RequestDecodingAdapter<? super T> adapter,
-            Enforcement localEnforcement) {
+            Enforcement enforcementStrategy) {
         Long headerDeadline =
                 tryParseSecondsToNanoseconds(adapter.maybeFirstHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN));
 
         // check enforcement
         Enforcement stateEnforcement;
-        if (localEnforcement == Enforcement.DISABLE) {
+        if (enforcementStrategy == Enforcement.DISABLE) {
             stateEnforcement = Enforcement.DISABLE;
         } else {
             // check for the `Expect-Within-Enforced` flag in a header and set the outbound enforcement state
@@ -269,11 +272,11 @@ public final class Deadlines {
             // OutboundEnforcement.ENFORCE : OutboundEnforcement.DEFER
             String headerEnforced = adapter.maybeFirstHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED);
             if (headerEnforced == null) {
-                stateEnforcement = localEnforcement == Enforcement.ENFORCE ? Enforcement.ENFORCE : Enforcement.DEFER;
+                stateEnforcement = enforcementStrategy == Enforcement.ENFORCE ? Enforcement.ENFORCE : Enforcement.DEFER;
             } else {
                 if (headerDeadline == null) {
                     stateEnforcement =
-                            localEnforcement == Enforcement.ENFORCE ? Enforcement.ENFORCE : Enforcement.DEFER;
+                            enforcementStrategy == Enforcement.ENFORCE ? Enforcement.ENFORCE : Enforcement.DEFER;
                 } else {
                     if (headerEnforced.equalsIgnoreCase("true")) {
                         stateEnforcement = Enforcement.ENFORCE;
@@ -281,7 +284,7 @@ public final class Deadlines {
                         stateEnforcement = Enforcement.DISABLE;
                     } else {
                         stateEnforcement =
-                                localEnforcement == Enforcement.ENFORCE ? Enforcement.ENFORCE : Enforcement.DEFER;
+                                enforcementStrategy == Enforcement.ENFORCE ? Enforcement.ENFORCE : Enforcement.DEFER;
                     }
                 }
             }

--- a/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
@@ -92,7 +92,8 @@ public final class Deadlines {
                     currentState.wallClockNanos(),
                     currentState.internal(),
                     true,
-                    currentState.enforcement()));
+                    // set the enforcement to DEFER to avoid having checkExpiration throw
+                    Enforcement.DEFER));
         }
     }
 

--- a/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
@@ -130,7 +130,7 @@ public final class Deadlines {
                     false);
             adapter.setHeader(
                     request, DeadlinesHttpHeaders.EXPECT_WITHIN, durationToHeaderValue(proposedDeadlineNanos));
-            adapter.setHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "false");
+            // we omit the enforcement flag header here to allow the next hop to decide the enforcement strategy
         } else {
             // use the minimum of proposedDeadline and the one read from state
             long remainingStateDeadlineNanos = stateDeadline.remainingNanos(getClockNanoTime());

--- a/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
@@ -92,7 +92,7 @@ public final class Deadlines {
                     currentState.wallClockNanos(),
                     currentState.internal(),
                     true,
-                    currentState.enforced()));
+                    currentState.enforcement()));
         }
     }
 
@@ -130,11 +130,11 @@ public final class Deadlines {
                     false);
             adapter.setHeader(
                     request, DeadlinesHttpHeaders.EXPECT_WITHIN, durationToHeaderValue(proposedDeadlineNanos));
-            // we omit the enforcement flag header here to allow the next hop to decide the enforcement strategy
         } else {
             // use the minimum of proposedDeadline and the one read from state
             long remainingStateDeadlineNanos = stateDeadline.remainingNanos(getClockNanoTime());
-            boolean enforced = stateDeadline.enforced();
+            OutboundEnforcement enforcement = stateDeadline.enforcement();
+            boolean enforced = enforcement == OutboundEnforcement.ENFORCE;
             if (proposedDeadlineNanos <= remainingStateDeadlineNanos) {
                 boolean proposedDeadlineAlreadyExpired = proposedDeadline.isNegative() || proposedDeadline.isZero();
                 checkExpiration(
@@ -146,7 +146,7 @@ public final class Deadlines {
                 if (!stateDeadline.disablePropagation()) {
                     adapter.setHeader(
                             request, DeadlinesHttpHeaders.EXPECT_WITHIN, durationToHeaderValue(proposedDeadlineNanos));
-                    adapter.setHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, Boolean.toString(enforced));
+                    encodeEnforcement(request, adapter, enforcement);
                 }
             } else {
                 checkExpiration(
@@ -160,9 +160,18 @@ public final class Deadlines {
                             request,
                             DeadlinesHttpHeaders.EXPECT_WITHIN,
                             durationToHeaderValue(remainingStateDeadlineNanos));
-                    adapter.setHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, Boolean.toString(enforced));
+                    encodeEnforcement(request, adapter, enforcement);
                 }
             }
+        }
+    }
+
+    private static <T> void encodeEnforcement(
+            T request, RequestEncodingAdapter<? super T> adapter, OutboundEnforcement enforcement) {
+        if (enforcement == OutboundEnforcement.ENFORCE) {
+            adapter.setHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "true");
+        } else if (enforcement == OutboundEnforcement.DISABLE) {
+            adapter.setHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "false");
         }
     }
 
@@ -197,14 +206,20 @@ public final class Deadlines {
         ENFORCED_IF_REQUESTED,
 
         /**
-         * IGNORED means that deadline expiration will be ignored at this node, and ALL downstream nodes, regardless
+         * DISABLED means that deadline expiration will be ignored at this node, and ALL downstream nodes, regardless
          * of whether an {@link DeadlinesHttpHeaders#EXPECT_WITHIN_ENFORCED} header was received with the value
          * set to `true`. Future calls to {@link #encodeToRequest} will not throw an exception if the deadline has
          * expired, and will set add a {@link DeadlinesHttpHeaders#EXPECT_WITHIN_ENFORCED} header on the request to
          * `false`. This effectively terminates deadline enforcement at this node and causes downstream nodes to
          * ignore further enforcement for this trace, regardless of their configured enforcement state.
          */
-        IGNORED
+        DISABLED
+    }
+
+    private enum OutboundEnforcement {
+        ENFORCE,
+        DEFER,
+        DISABLE
     }
 
     /**
@@ -242,54 +257,57 @@ public final class Deadlines {
                 tryParseSecondsToNanoseconds(adapter.maybeFirstHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN));
 
         // check enforcement
-        // if enforcement was explicitly disabled via `Expect-Within-Enforced: false`, then we honor that
-        boolean enforced;
-        if (enforcement == Enforcement.IGNORED) {
-            enforced = false;
+        OutboundEnforcement stateEnforcement;
+        if (enforcement == Enforcement.DISABLED) {
+            stateEnforcement = OutboundEnforcement.DISABLE;
         } else {
-            // check for the `Expect-Within-Enforced` flag in a header
+            // check for the `Expect-Within-Enforced` flag in a header and set the outbound enforcement state
+            // accordingly
             // possible outcomes:
-            //   - the header is not present and enforcement == ENFORCED => enforced=true
-            //   - the header is not present and enforcement == ENFORCED_IF_REQUESTED => enforced=false
-            //   - the header is present and the value is "true" => enforced=true
-            //   - the header is present and the value is "false" => enforced=false
-            //       (the rationale for this is that even if local enforcement was requested, if an upstream hop
-            //       requested that it _not_ be enforced then we will honor that instead)
-            //   - the header is present and the value is something else => enforced=(enforcement == ENFORCED)
-            //       (the rationale for this is that if we received a bogus value, we should just make a local decision)
-            //   - the header is present, but the `Expect-Within` header is absent => enforced=(enforcement == ENFORCED)
-            //       (the rationale for this is that we are selecting our own deadline, even though we received an
-            //       enforcement flag, so we should make a local decision)
+            //   - the header is not present => enforcement == ENFORCED ? OutboundEnforcement.ENFORCE :
+            // OutboundEnforcement.DEFER
+            //   - the header is present and the value is "true" => OutboundEnforcement.ENFORCE
+            //   - the header is present and the value is "false" => OutboundEnforcement.DISABLE
+            //   - the header is present and the value is something else => enforcement == ENFORCED ?
+            // OutboundEnforcement.ENFORCE : OutboundEnforcement.DEFER
+            //   - the header is present but the `Expect-Within` header is absent => enforcement == ENFORCED ?
+            // OutboundEnforcement.ENFORCE : OutboundEnforcement.DEFER
             String headerEnforced = adapter.maybeFirstHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED);
             if (headerEnforced == null) {
-                enforced = enforcement == Enforcement.ENFORCED;
+                stateEnforcement =
+                        enforcement == Enforcement.ENFORCED ? OutboundEnforcement.ENFORCE : OutboundEnforcement.DEFER;
             } else {
                 if (headerDeadline == null) {
-                    enforced = enforcement == Enforcement.ENFORCED;
+                    stateEnforcement = enforcement == Enforcement.ENFORCED
+                            ? OutboundEnforcement.ENFORCE
+                            : OutboundEnforcement.DEFER;
                 } else {
                     if (headerEnforced.equalsIgnoreCase("true")) {
-                        enforced = true;
+                        stateEnforcement = OutboundEnforcement.ENFORCE;
                     } else if (headerEnforced.equalsIgnoreCase("false")) {
-                        enforced = false;
+                        stateEnforcement = OutboundEnforcement.DISABLE;
                     } else {
-                        enforced = enforcement == Enforcement.ENFORCED;
+                        stateEnforcement = enforcement == Enforcement.ENFORCED
+                                ? OutboundEnforcement.ENFORCE
+                                : OutboundEnforcement.DEFER;
                     }
                 }
             }
         }
+
         if (headerDeadline != null && internalDeadline.isEmpty()) {
             // use the deadline parsed from a header, which is considered external
-            storeDeadline(headerDeadline, false, enforced);
+            storeDeadline(headerDeadline, false, stateEnforcement);
         } else if (headerDeadline == null && internalDeadline.isPresent()) {
             // use the deadline provided to this method, which is considered internal
-            storeDeadline(internalDeadline.get().toNanos(), true, enforced);
+            storeDeadline(internalDeadline.get().toNanos(), true, stateEnforcement);
         } else if (headerDeadline != null) {
             // both present, so use the one that's lower
             long internalDeadlineValue = internalDeadline.get().toNanos();
             if (headerDeadline <= internalDeadlineValue) {
-                storeDeadline(headerDeadline, false, enforced);
+                storeDeadline(headerDeadline, false, stateEnforcement);
             } else {
-                storeDeadline(internalDeadlineValue, true, enforced);
+                storeDeadline(internalDeadlineValue, true, stateEnforcement);
             }
         }
 
@@ -299,13 +317,13 @@ public final class Deadlines {
     @Deprecated
     public static <T> void parseFromRequest(
             Optional<Duration> internalDeadline, T request, RequestDecodingAdapter<? super T> adapter) {
-        // by default use IGNORED, which matches behavior of consumers on older versions which have no enforcement
-        parseFromRequest(internalDeadline, request, adapter, Enforcement.IGNORED);
+        // by default use DISABLED, which matches behavior of consumers on older versions which have no enforcement
+        parseFromRequest(internalDeadline, request, adapter, Enforcement.DISABLED);
     }
 
-    private static void storeDeadline(long deadline, boolean internal, boolean enforced) {
+    private static void storeDeadline(long deadline, boolean internal, OutboundEnforcement enforcement) {
         ProvidedDeadline providedDeadline =
-                new ProvidedDeadline(deadline, getClockNanoTime(), internal, false, enforced);
+                new ProvidedDeadline(deadline, getClockNanoTime(), internal, false, enforcement);
         deadlineState.set(providedDeadline);
     }
 
@@ -412,7 +430,11 @@ public final class Deadlines {
     }
 
     private record ProvidedDeadline(
-            long valueNanos, long wallClockNanos, boolean internal, boolean disablePropagation, boolean enforced) {
+            long valueNanos,
+            long wallClockNanos,
+            boolean internal,
+            boolean disablePropagation,
+            OutboundEnforcement enforcement) {
         long remainingNanos(long currentWallClockNanos) {
             long elapsed = currentWallClockNanos - this.wallClockNanos;
             return valueNanos - elapsed;

--- a/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
@@ -169,14 +169,14 @@ public final class Deadlines {
 
     private static <T> void encodeEnforcement(
             T request, RequestEncodingAdapter<? super T> adapter, Enforcement enforcement) {
-        String value =
+        String headerValue =
                 switch (enforcement) {
-                    case ENFORCE -> "true";
                     case DISABLE -> "false";
-                    default -> null;
+                    case ENFORCE -> "true";
+                    case DEFER -> null;
                 };
-        if (value != null) {
-            adapter.setHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, value);
+        if (headerValue != null) {
+            adapter.setHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, headerValue);
         }
     }
 
@@ -224,6 +224,46 @@ public final class Deadlines {
         DISABLE
     }
 
+    private static Enforcement resolveEnforcementStrategy(
+            @Nullable String headerEnforced, boolean headerDeadlineSet, Enforcement enforcementStrategy) {
+        // check for the `Expect-Within-Enforced` flag in a header and set the outbound enforcement state
+        // accordingly
+        // possible outcomes:
+        //   - the header is not present => enforcement == ENFORCE ? ENFORCE : DEFER
+        //   - the header is present and the value is "true" => ENFORCE
+        //   - the header is present and the value is "false" => DISABLE
+        //   - the header is present and the value is something else => enforcement == ENFORCED ? ENFORCE : DEFER
+        //   - the header is present but the `Expect-Within` header is absent => enforcement == ENFORCED ? ENFORCE :
+        // DEFER
+        return switch (enforcementStrategy) {
+            case DISABLE -> Enforcement.DISABLE;
+            case ENFORCE -> {
+                // If the header deadline is not set, set the enforcement header to the provided enforcement strategy
+                // irrespective of the existing enforcement header.
+                if (!headerDeadlineSet) {
+                    yield Enforcement.ENFORCE;
+                }
+                // Deadlines will be enforced unless the header explicitly disables it.
+                if (headerEnforced != null && headerEnforced.equalsIgnoreCase("false")) {
+                    yield Enforcement.DISABLE;
+                }
+                yield Enforcement.ENFORCE;
+            }
+            case DEFER -> {
+                if (!headerDeadlineSet || headerEnforced == null) {
+                    yield Enforcement.DEFER;
+                }
+                if (headerEnforced.equalsIgnoreCase("true")) {
+                    yield Enforcement.ENFORCE;
+                } else if (headerEnforced.equalsIgnoreCase("false")) {
+                    yield Enforcement.DISABLE;
+                } else {
+                    yield Enforcement.DEFER;
+                }
+            }
+        };
+    }
+
     /**
      * Parse a deadline value from a request header and set the deadline state for the current trace.
      *
@@ -249,7 +289,6 @@ public final class Deadlines {
      * @param adapter a {@link RequestDecodingAdapter} that handles reading the header value from the request object
      * @param enforcementStrategy configures enforcement strategy (see {@link Enforcement})
      */
-    @SuppressWarnings("CyclomaticComplexity")
     public static <T> void parseFromRequest(
             Optional<Duration> internalDeadline,
             T request,
@@ -257,58 +296,26 @@ public final class Deadlines {
             Enforcement enforcementStrategy) {
         Long headerDeadline =
                 tryParseSecondsToNanoseconds(adapter.maybeFirstHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN));
-
-        // check enforcement
-        Enforcement stateEnforcement;
-        if (enforcementStrategy == Enforcement.DISABLE) {
-            stateEnforcement = Enforcement.DISABLE;
-        } else {
-            // check for the `Expect-Within-Enforced` flag in a header and set the outbound enforcement state
-            // accordingly
-            // possible outcomes:
-            //   - the header is not present => enforcement == ENFORCED ? Enforcement.ENFORCE : Enforcement.DEFER
-            //   - the header is present and the value is "true" => Enforcement.ENFORCE
-            //   - the header is present and the value is "false" => Enforcement.DISABLE
-            //   - the header is present and the value is something else => enforcement == ENFORCED ?
-            // Enforcement.ENFORCE : Enforcement.DEFER
-            //   - the header is present but the `Expect-Within` header is absent => enforcement == ENFORCED ?
-            // Enforcement.ENFORCE : Enforcement.DEFER
-            String headerEnforced = adapter.maybeFirstHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED);
-            if (headerEnforced == null) {
-                stateEnforcement = enforcementStrategy == Enforcement.ENFORCE ? Enforcement.ENFORCE : Enforcement.DEFER;
-            } else {
-                if (headerDeadline == null) {
-                    stateEnforcement =
-                            enforcementStrategy == Enforcement.ENFORCE ? Enforcement.ENFORCE : Enforcement.DEFER;
-                } else {
-                    if (headerEnforced.equalsIgnoreCase("true")) {
-                        stateEnforcement = Enforcement.ENFORCE;
-                    } else if (headerEnforced.equalsIgnoreCase("false")) {
-                        stateEnforcement = Enforcement.DISABLE;
-                    } else {
-                        stateEnforcement =
-                                enforcementStrategy == Enforcement.ENFORCE ? Enforcement.ENFORCE : Enforcement.DEFER;
-                    }
-                }
-            }
-        }
-
-        if (headerDeadline != null && internalDeadline.isEmpty()) {
-            // use the deadline parsed from a header, which is considered external
-            storeDeadline(headerDeadline, false, stateEnforcement);
-        } else if (headerDeadline == null && internalDeadline.isPresent()) {
-            // use the deadline provided to this method, which is considered internal
-            storeDeadline(internalDeadline.get().toNanos(), true, stateEnforcement);
-        } else if (headerDeadline != null) {
-            // both present, so use the one that's lower
-            long internalDeadlineValue = internalDeadline.get().toNanos();
-            if (headerDeadline <= internalDeadlineValue) {
+        String headerEnforced = adapter.maybeFirstHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED);
+        Enforcement stateEnforcement =
+                resolveEnforcementStrategy(headerEnforced, headerDeadline != null, enforcementStrategy);
+        if (headerDeadline != null) {
+            if (internalDeadline.isEmpty()) {
+                // use the deadline parsed from a header, which is considered external
                 storeDeadline(headerDeadline, false, stateEnforcement);
             } else {
-                storeDeadline(internalDeadlineValue, true, stateEnforcement);
+                // both present, so use the one that's lower
+                long internalDeadlineValue = internalDeadline.get().toNanos();
+                if (headerDeadline <= internalDeadlineValue) {
+                    storeDeadline(headerDeadline, false, stateEnforcement);
+                } else {
+                    storeDeadline(internalDeadlineValue, true, stateEnforcement);
+                }
             }
+        } else if (internalDeadline.isPresent()) {
+            // use the deadline provided to this method, which is considered internal
+            storeDeadline(internalDeadline.get().toNanos(), true, stateEnforcement);
         }
-
         // no-op if neither header is present nor optional internalDeadline is present
     }
 

--- a/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
@@ -88,7 +88,11 @@ public final class Deadlines {
         if (currentState != null && !currentState.disablePropagation()) {
             // does not check for expiration
             deadlineState.set(new ProvidedDeadline(
-                    currentState.valueNanos(), currentState.wallClockNanos(), currentState.internal(), true));
+                    currentState.valueNanos(),
+                    currentState.wallClockNanos(),
+                    currentState.internal(),
+                    true,
+                    currentState.enforced()));
         }
     }
 
@@ -114,34 +118,52 @@ public final class Deadlines {
         long proposedDeadlineNanos = proposedDeadline.toNanos();
         if (stateDeadline == null) {
             // use proposedDeadline
-            checkExpiration(proposedDeadlineNanos, false, false, false);
+            checkExpiration(
+                    proposedDeadlineNanos,
+                    false,
+                    false,
+                    false,
+                    // don't bother with enforcement here
+                    // if we don't have any existing deadline state, then we're merely checking that the caller
+                    // didn't pass in a negative deadline to this method
+                    // eventually, enforcement will be on by default anyway
+                    false);
             adapter.setHeader(
                     request, DeadlinesHttpHeaders.EXPECT_WITHIN, durationToHeaderValue(proposedDeadlineNanos));
         } else {
             // use the minimum of proposedDeadline and the one read from state
             long remainingStateDeadlineNanos = stateDeadline.remainingNanos(getClockNanoTime());
+            boolean enforced = stateDeadline.enforced();
             if (proposedDeadlineNanos <= remainingStateDeadlineNanos) {
                 boolean proposedDeadlineAlreadyExpired = proposedDeadline.isNegative() || proposedDeadline.isZero();
                 checkExpiration(
                         proposedDeadlineNanos,
                         false,
                         stateDeadline.disablePropagation(),
-                        proposedDeadlineAlreadyExpired);
+                        proposedDeadlineAlreadyExpired,
+                        enforced);
                 if (!stateDeadline.disablePropagation()) {
                     adapter.setHeader(
                             request, DeadlinesHttpHeaders.EXPECT_WITHIN, durationToHeaderValue(proposedDeadlineNanos));
+                    if (enforced) {
+                        adapter.setHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "true");
+                    }
                 }
             } else {
                 checkExpiration(
                         remainingStateDeadlineNanos,
                         stateDeadline.internal(),
                         stateDeadline.disablePropagation(),
-                        stateDeadline.alreadyExpired());
+                        stateDeadline.alreadyExpired(),
+                        enforced);
                 if (!stateDeadline.disablePropagation()) {
                     adapter.setHeader(
                             request,
                             DeadlinesHttpHeaders.EXPECT_WITHIN,
                             durationToHeaderValue(remainingStateDeadlineNanos));
+                    if (enforced) {
+                        adapter.setHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "true");
+                    }
                 }
             }
         }
@@ -155,6 +177,15 @@ public final class Deadlines {
      * {@link #getRemainingDeadline()}} from threads participating in the current trace. The deadline value
      * is read from a {@link DeadlinesHttpHeaders#EXPECT_WITHIN} header on the request object.
      *
+     * Enforcement of the deadline is enabled in onw of two ways:
+     *   - Callers can set the "internalEnforced" parameter on this method to true.
+     *   - If an "Expect-Within-Enforced" header is present in the request with a value of "true",
+     *     it will enable enforcement.
+     * If either of those conditions are met, the deadline state stored in the TraceLocal will additionally
+     * set an enforcement flag. This will indicate to future calls to {@link #encodeToRequest} that it should check
+     * for and enforce expiration. It also causes those calls to further propagate an "Expect-Within-Enforced" header,
+     * so that downstream receivers will also be required to enforce the deadline expiration.
+     *
      * This function has side-effects on the internal deadline state stored in a TraceLocal; the state is
      * set (or overwritten) based on the value of the deadline parsed from request headers.
      *
@@ -162,37 +193,54 @@ public final class Deadlines {
      * lower than the one parsed from a request header
      * @param request the request object to read the deadline value from
      * @param adapter a {@link RequestDecodingAdapter} that handles reading the header value from the request object
+     * @param internalEnforced whether this deadline should be enforced at this hop (and all downstream receivers)
      */
     public static <T> void parseFromRequest(
-            Optional<Duration> internalDeadline, T request, RequestDecodingAdapter<? super T> adapter) {
+            Optional<Duration> internalDeadline,
+            T request,
+            RequestDecodingAdapter<? super T> adapter,
+            boolean internalEnforced) {
         Long headerDeadline =
                 tryParseSecondsToNanoseconds(adapter.maybeFirstHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN));
+        String headerEnforced = adapter.maybeFirstHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED);
+        boolean enforced = internalEnforced || (headerEnforced != null && headerEnforced.equalsIgnoreCase("true"));
         if (headerDeadline != null && internalDeadline.isEmpty()) {
             // use the deadline parsed from a header, which is considered external
-            storeDeadline(headerDeadline, false);
+            storeDeadline(headerDeadline, false, enforced);
         } else if (headerDeadline == null && internalDeadline.isPresent()) {
             // use the deadline provided to this method, which is considered internal
-            storeDeadline(internalDeadline.get().toNanos(), true);
+            storeDeadline(
+                    internalDeadline.get().toNanos(),
+                    true,
+                    // avoid scenarios where Expect-Within-Enforced is present, but Expect-Within is absent
+                    internalEnforced);
         } else if (headerDeadline != null) {
             // both present, so use the one that's lower
             long internalDeadlineValue = internalDeadline.get().toNanos();
             if (headerDeadline <= internalDeadlineValue) {
-                storeDeadline(headerDeadline, false);
+                storeDeadline(headerDeadline, false, enforced);
             } else {
-                storeDeadline(internalDeadlineValue, true);
+                storeDeadline(internalDeadlineValue, true, enforced);
             }
         }
 
         // no-op if neither header is present nor optional internalDeadline is present
     }
 
-    private static void storeDeadline(long deadline, boolean internal) {
-        ProvidedDeadline providedDeadline = new ProvidedDeadline(deadline, getClockNanoTime(), internal, false);
+    @Deprecated
+    public static <T> void parseFromRequest(
+            Optional<Duration> internalDeadline, T request, RequestDecodingAdapter<? super T> adapter) {
+        parseFromRequest(internalDeadline, request, adapter, false);
+    }
+
+    private static void storeDeadline(long deadline, boolean internal, boolean enforced) {
+        ProvidedDeadline providedDeadline =
+                new ProvidedDeadline(deadline, getClockNanoTime(), internal, false, enforced);
         deadlineState.set(providedDeadline);
     }
 
     private static void checkExpiration(
-            long deadline, boolean internal, boolean disablePropagation, boolean alreadyExpired) {
+            long deadline, boolean internal, boolean disablePropagation, boolean alreadyExpired, boolean enforced) {
         if (deadline <= 0) {
             // expired
             Expired_Cause cause = internal ? Expired_Cause.INTERNAL : Expired_Cause.EXTERNAL;
@@ -203,7 +251,9 @@ public final class Deadlines {
                 intent = Expired_Intent.PROPAGATE_ALREADY_EXPIRED;
             }
             metrics.expired().cause(cause).intent(intent).build().mark();
-            // TODO(blaub): throw exception instead of return
+            if (enforced) {
+                throw internal ? DeadlineExpiredException.internal() : DeadlineExpiredException.external();
+            }
         }
     }
 
@@ -292,7 +342,7 @@ public final class Deadlines {
     }
 
     private record ProvidedDeadline(
-            long valueNanos, long wallClockNanos, boolean internal, boolean disablePropagation) {
+            long valueNanos, long wallClockNanos, boolean internal, boolean disablePropagation, boolean enforced) {
         long remainingNanos(long currentWallClockNanos) {
             long elapsed = currentWallClockNanos - this.wallClockNanos;
             return valueNanos - elapsed;

--- a/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
@@ -266,14 +266,13 @@ public final class Deadlines {
             // check for the `Expect-Within-Enforced` flag in a header and set the outbound enforcement state
             // accordingly
             // possible outcomes:
-            //   - the header is not present => enforcement == ENFORCED ? OutboundEnforcement.ENFORCE :
-            // OutboundEnforcement.DEFER
-            //   - the header is present and the value is "true" => OutboundEnforcement.ENFORCE
-            //   - the header is present and the value is "false" => OutboundEnforcement.DISABLE
+            //   - the header is not present => enforcement == ENFORCED ? Enforcement.ENFORCE : Enforcement.DEFER
+            //   - the header is present and the value is "true" => Enforcement.ENFORCE
+            //   - the header is present and the value is "false" => Enforcement.DISABLE
             //   - the header is present and the value is something else => enforcement == ENFORCED ?
-            // OutboundEnforcement.ENFORCE : OutboundEnforcement.DEFER
+            // Enforcement.ENFORCE : Enforcement.DEFER
             //   - the header is present but the `Expect-Within` header is absent => enforcement == ENFORCED ?
-            // OutboundEnforcement.ENFORCE : OutboundEnforcement.DEFER
+            // Enforcement.ENFORCE : Enforcement.DEFER
             String headerEnforced = adapter.maybeFirstHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED);
             if (headerEnforced == null) {
                 stateEnforcement = enforcementStrategy == Enforcement.ENFORCE ? Enforcement.ENFORCE : Enforcement.DEFER;

--- a/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
@@ -202,8 +202,11 @@ public final class Deadlines {
             boolean internalEnforced) {
         Long headerDeadline =
                 tryParseSecondsToNanoseconds(adapter.maybeFirstHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN));
-        String headerEnforced = adapter.maybeFirstHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED);
-        boolean enforced = internalEnforced || (headerEnforced != null && headerEnforced.equalsIgnoreCase("true"));
+        boolean enforced = internalEnforced;
+        if (!enforced) {
+            String headerEnforced = adapter.maybeFirstHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED);
+            enforced = headerEnforced != null && headerEnforced.equalsIgnoreCase("true");
+        }
         if (headerDeadline != null && internalDeadline.isEmpty()) {
             // use the deadline parsed from a header, which is considered external
             storeDeadline(headerDeadline, false, enforced);

--- a/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
@@ -133,8 +133,8 @@ public final class Deadlines {
         } else {
             // use the minimum of proposedDeadline and the one read from state
             long remainingStateDeadlineNanos = stateDeadline.remainingNanos(getClockNanoTime());
-            OutboundEnforcement enforcement = stateDeadline.enforcement();
-            boolean enforced = enforcement == OutboundEnforcement.ENFORCE;
+            Enforcement enforcement = stateDeadline.enforcement();
+            boolean enforced = enforcement == Enforcement.ENFORCE;
             if (proposedDeadlineNanos <= remainingStateDeadlineNanos) {
                 boolean proposedDeadlineAlreadyExpired = proposedDeadline.isNegative() || proposedDeadline.isZero();
                 checkExpiration(
@@ -167,10 +167,10 @@ public final class Deadlines {
     }
 
     private static <T> void encodeEnforcement(
-            T request, RequestEncodingAdapter<? super T> adapter, OutboundEnforcement enforcement) {
-        if (enforcement == OutboundEnforcement.ENFORCE) {
+            T request, RequestEncodingAdapter<? super T> adapter, Enforcement enforcement) {
+        if (enforcement == Enforcement.ENFORCE) {
             adapter.setHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "true");
-        } else if (enforcement == OutboundEnforcement.DISABLE) {
+        } else if (enforcement == Enforcement.DISABLE) {
             adapter.setHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "false");
         }
     }
@@ -182,43 +182,36 @@ public final class Deadlines {
      * to {@link #encodeToRequest} for the current trace. Enabling enforcement means that a {@link DeadlineExpiredException}
      * will be thrown when a deadline is detected to have expired, and that an enforcement flag will be propagated
      * when encoding a deadline for a new outbound request.
-     *
-     * There are 3 possible states (described below) to control enforcement; they determine whether the current node
-     * will enforce deadline expirations here, and whether an enforcement flag may be added to future outbound requests;
-     * or whether deadline expirations will be ignored and the enforcement flag not propagated further.
      */
     public enum Enforcement {
         /**
-         * ENFORCED means that future calls to {@link #encodeToRequest} will throw an exception if the deadline has
-         * expired, and also append an {@link DeadlinesHttpHeaders#EXPECT_WITHIN_ENFORCED} header
-         * when encoding future deadlines from the current trace to request enforcement from downstream nodes as well.
+         * ENFORCE means that future calls to {@link #encodeToRequest} will throw an exception if the deadline has
+         * expired, and also append an {@link DeadlinesHttpHeaders#EXPECT_WITHIN_ENFORCED} header with the value set
+         * to "true" when encoding future deadlines from the current trace to request enforcement from downstream
+         * nodes as well.
          */
-        ENFORCED,
+        ENFORCE,
 
         /**
-         * ENFORCED_IF_REQUESTED means that future calls to {@link #encodeToRequest} will throw an exception if the
-         * deadline has expired, but only if enforcement was requested at the time we parsed a deadline value from
-         * a request header (e.g. if {@link #parseFromRequest} received an
-         * {@link DeadlinesHttpHeaders#EXPECT_WITHIN_ENFORCED} header set to `true`). Otherwise, no deadline expiration
-         * enforcement will happen at this node, and we propagate an {@link DeadlinesHttpHeaders#EXPECT_WITHIN_ENFORCED}
-         * header set to `false` so that downstream nodes do not enforce the deadline either.
+         * DEFER means that future calls to {@link #encodeToRequest} MAY throw an exception if the deadline
+         * has expired, but only if enforcement was requested at the time we parsed a deadline value from
+         * a request header (e.g. if {@link #parseFromRequest} received an {@link DeadlinesHttpHeaders#EXPECT_WITHIN_ENFORCED}
+         * header set to "true"). Otherwise, no deadline expiration enforcement will happen at this node, and we will
+         * omit {@link DeadlinesHttpHeaders#EXPECT_WITHIN_ENFORCED} headers on future outbound requests.
+         *
+         * DEFER is used to indicate that we are deferring the enforcement strategy to either the inbound request,
+         * or the next downstream hop, but will not enable enforcement here.
          */
-        ENFORCED_IF_REQUESTED,
+        DEFER,
 
         /**
-         * DISABLED means that deadline expiration will be ignored at this node, and ALL downstream nodes, regardless
+         * DISABLE means that deadline expiration will be ignored at this node, and ALL downstream nodes, regardless
          * of whether an {@link DeadlinesHttpHeaders#EXPECT_WITHIN_ENFORCED} header was received with the value
-         * set to `true`. Future calls to {@link #encodeToRequest} will not throw an exception if the deadline has
+         * set to "true". Future calls to {@link #encodeToRequest} will not throw an exception if the deadline has
          * expired, and will set add a {@link DeadlinesHttpHeaders#EXPECT_WITHIN_ENFORCED} header on the request to
-         * `false`. This effectively terminates deadline enforcement at this node and causes downstream nodes to
+         * "false". This effectively terminates deadline enforcement at this node and causes downstream nodes to
          * ignore further enforcement for this trace, regardless of their configured enforcement state.
          */
-        DISABLED
-    }
-
-    private enum OutboundEnforcement {
-        ENFORCE,
-        DEFER,
         DISABLE
     }
 
@@ -246,21 +239,21 @@ public final class Deadlines {
      * lower than the one parsed from a request header
      * @param request the request object to read the deadline value from
      * @param adapter a {@link RequestDecodingAdapter} that handles reading the header value from the request object
-     * @param enforcement configures enforcement strategy (see {@link Enforcement})
+     * @param localEnforcement configures enforcement strategy (see {@link Enforcement})
      */
     @SuppressWarnings("CyclomaticComplexity")
     public static <T> void parseFromRequest(
             Optional<Duration> internalDeadline,
             T request,
             RequestDecodingAdapter<? super T> adapter,
-            Enforcement enforcement) {
+            Enforcement localEnforcement) {
         Long headerDeadline =
                 tryParseSecondsToNanoseconds(adapter.maybeFirstHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN));
 
         // check enforcement
-        OutboundEnforcement stateEnforcement;
-        if (enforcement == Enforcement.DISABLED) {
-            stateEnforcement = OutboundEnforcement.DISABLE;
+        Enforcement stateEnforcement;
+        if (localEnforcement == Enforcement.DISABLE) {
+            stateEnforcement = Enforcement.DISABLE;
         } else {
             // check for the `Expect-Within-Enforced` flag in a header and set the outbound enforcement state
             // accordingly
@@ -275,22 +268,19 @@ public final class Deadlines {
             // OutboundEnforcement.ENFORCE : OutboundEnforcement.DEFER
             String headerEnforced = adapter.maybeFirstHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED);
             if (headerEnforced == null) {
-                stateEnforcement =
-                        enforcement == Enforcement.ENFORCED ? OutboundEnforcement.ENFORCE : OutboundEnforcement.DEFER;
+                stateEnforcement = localEnforcement == Enforcement.ENFORCE ? Enforcement.ENFORCE : Enforcement.DEFER;
             } else {
                 if (headerDeadline == null) {
-                    stateEnforcement = enforcement == Enforcement.ENFORCED
-                            ? OutboundEnforcement.ENFORCE
-                            : OutboundEnforcement.DEFER;
+                    stateEnforcement =
+                            localEnforcement == Enforcement.ENFORCE ? Enforcement.ENFORCE : Enforcement.DEFER;
                 } else {
                     if (headerEnforced.equalsIgnoreCase("true")) {
-                        stateEnforcement = OutboundEnforcement.ENFORCE;
+                        stateEnforcement = Enforcement.ENFORCE;
                     } else if (headerEnforced.equalsIgnoreCase("false")) {
-                        stateEnforcement = OutboundEnforcement.DISABLE;
+                        stateEnforcement = Enforcement.DISABLE;
                     } else {
-                        stateEnforcement = enforcement == Enforcement.ENFORCED
-                                ? OutboundEnforcement.ENFORCE
-                                : OutboundEnforcement.DEFER;
+                        stateEnforcement =
+                                localEnforcement == Enforcement.ENFORCE ? Enforcement.ENFORCE : Enforcement.DEFER;
                     }
                 }
             }
@@ -318,12 +308,11 @@ public final class Deadlines {
     @Deprecated
     public static <T> void parseFromRequest(
             Optional<Duration> internalDeadline, T request, RequestDecodingAdapter<? super T> adapter) {
-        // by default use ENFORCED_IF_REQUESTED, which matches behavior of consumers on older versions which have no
-        // enforcement
-        parseFromRequest(internalDeadline, request, adapter, Enforcement.ENFORCED_IF_REQUESTED);
+        // by default use DEFER, which matches behavior of consumers on older versions which have no enforcement
+        parseFromRequest(internalDeadline, request, adapter, Enforcement.DEFER);
     }
 
-    private static void storeDeadline(long deadline, boolean internal, OutboundEnforcement enforcement) {
+    private static void storeDeadline(long deadline, boolean internal, Enforcement enforcement) {
         ProvidedDeadline providedDeadline =
                 new ProvidedDeadline(deadline, getClockNanoTime(), internal, false, enforcement);
         deadlineState.set(providedDeadline);
@@ -436,7 +425,7 @@ public final class Deadlines {
             long wallClockNanos,
             boolean internal,
             boolean disablePropagation,
-            OutboundEnforcement enforcement) {
+            Enforcement enforcement) {
         long remainingNanos(long currentWallClockNanos) {
             long elapsed = currentWallClockNanos - this.wallClockNanos;
             return valueNanos - elapsed;

--- a/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
@@ -169,10 +169,14 @@ public final class Deadlines {
 
     private static <T> void encodeEnforcement(
             T request, RequestEncodingAdapter<? super T> adapter, Enforcement enforcement) {
-        if (enforcement == Enforcement.ENFORCE) {
-            adapter.setHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "true");
-        } else if (enforcement == Enforcement.DISABLE) {
-            adapter.setHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "false");
+        String value =
+                switch (enforcement) {
+                    case ENFORCE -> "true";
+                    case DISABLE -> "false";
+                    default -> null;
+                };
+        if (value != null) {
+            adapter.setHeader(request, DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, value);
         }
     }
 

--- a/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
@@ -232,10 +232,12 @@ public final class Deadlines {
         // possible outcomes:
         //   - the enforcementStrategy == DISABLED => DISABLED
         //   - the header is not present => enforcementStrategy == ENFORCE ? ENFORCE : DEFER
-        //   - the header is present but the `Expect-Within` header is absent => enforcementStrategy == ENFORCED ? ENFORCE :  DEFER
+        //   - the header is present but the `Expect-Within` header is absent => enforcementStrategy == ENFORCED ?
+        // ENFORCE :  DEFER
         //   - the header is present and the value is "true" => ENFORCE
         //   - the header is present and the value is "false" => DISABLE
-        //   - the header is present and the value is something else => enforcementStrategy == ENFORCED ? ENFORCE : DEFER
+        //   - the header is present and the value is something else => enforcementStrategy == ENFORCED ? ENFORCE :
+        // DEFER
         return switch (enforcementStrategy) {
             case DISABLE -> Enforcement.DISABLE;
             case ENFORCE -> {

--- a/deadlines/src/main/java/com/palantir/deadlines/DeadlinesHttpHeaders.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/DeadlinesHttpHeaders.java
@@ -18,5 +18,6 @@ package com.palantir.deadlines;
 
 interface DeadlinesHttpHeaders {
     String EXPECT_WITHIN = "Expect-Within";
+    String EXPECT_WITHIN_ENFORCED = "Expect-Within-Enforced";
     String DEADLINE_EXPIRED_REASON = "Deadline-Expired-Reason";
 }

--- a/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
+++ b/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
@@ -754,6 +754,22 @@ class DeadlinesTest {
     }
 
     @Test
+    public void test_propagate_enforcement_missing_deadline_local_disabled() {
+        // ensure that when the `Expect-Within` header is missing, the external `Expect-Within-Enforced` flag is ignored
+        try (CloseableTracer ignored = CloseableTracer.startSpan("test")) {
+            Map<String, String> inbound1 = new HashMap<>();
+            inbound1.put(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "true");
+            Deadlines.parseFromRequest(
+                    Optional.of(Duration.ofSeconds(10)), inbound1, DummyRequestDecoder.INSTANCE, Enforcement.DISABLE);
+
+            Map<String, String> outbound = new HashMap<>();
+            Deadlines.encodeToRequest(Duration.ofSeconds(10), outbound, DummyRequestEncoder.INSTANCE);
+
+            assertThat(outbound).containsEntry(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "false");
+        }
+    }
+
+    @Test
     public void test_propagate_enforcement_bogus_external_flag_local_enforced() {
         // ensure that when the `Expect-Within-Enforced` flag contains an unknown value, it is ignored
         try (CloseableTracer ignored = CloseableTracer.startSpan("test")) {
@@ -788,6 +804,25 @@ class DeadlinesTest {
             Deadlines.encodeToRequest(Duration.ofSeconds(10), outbound, DummyRequestEncoder.INSTANCE);
 
             assertThat(outbound).doesNotContainKey(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED);
+        }
+    }
+
+    @Test
+    public void test_propagate_enforcement_bogus_external_flag_local_disabled() {
+        // ensure that when the `Expect-Within-Enforced` flag contains an unknown value, it is ignored
+        try (CloseableTracer ignored = CloseableTracer.startSpan("test")) {
+            Map<String, String> inbound1 = new HashMap<>();
+            Duration providedDeadline = Duration.ofSeconds(1);
+            inbound1.put(
+                    DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
+            inbound1.put(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "foobar");
+            Deadlines.parseFromRequest(
+                    Optional.of(Duration.ofSeconds(10)), inbound1, DummyRequestDecoder.INSTANCE, Enforcement.DISABLE);
+
+            Map<String, String> outbound = new HashMap<>();
+            Deadlines.encodeToRequest(Duration.ofSeconds(10), outbound, DummyRequestEncoder.INSTANCE);
+
+            assertThat(outbound).containsEntry(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "false");
         }
     }
 

--- a/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
+++ b/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
@@ -732,6 +732,9 @@ class DeadlinesTest {
         // ensure that when the `Expect-Within-Enforced` flag contains an unknown value, it is ignored
         try (CloseableTracer ignored = CloseableTracer.startSpan("test")) {
             Map<String, String> inbound1 = new HashMap<>();
+            Duration providedDeadline = Duration.ofSeconds(1);
+            inbound1.put(
+                    DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
             inbound1.put(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "foobar");
             Deadlines.parseFromRequest(
                     Optional.of(Duration.ofSeconds(10)), inbound1, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCED);
@@ -748,6 +751,9 @@ class DeadlinesTest {
         // ensure that when the `Expect-Within-Enforced` flag contains an unknown value, it is ignored
         try (CloseableTracer ignored = CloseableTracer.startSpan("test")) {
             Map<String, String> inbound1 = new HashMap<>();
+            Duration providedDeadline = Duration.ofSeconds(1);
+            inbound1.put(
+                    DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
             inbound1.put(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "foobar");
             Deadlines.parseFromRequest(
                     Optional.of(Duration.ofSeconds(10)),

--- a/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
+++ b/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
@@ -199,7 +199,7 @@ class DeadlinesTest {
             Duration providedDeadline = Duration.ofSeconds(1);
             request.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
-            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.DISABLED);
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.DISABLE);
 
             Optional<Duration> remaining = Deadlines.getRemainingDeadline();
             assertThat(remaining).hasValueSatisfying(d -> assertThat(d).isLessThanOrEqualTo(providedDeadline));
@@ -213,7 +213,7 @@ class DeadlinesTest {
             long originalDeadline = Duration.ofSeconds(1).toNanos();
             inboundRequest.put(DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(originalDeadline));
             Deadlines.parseFromRequest(
-                    Optional.empty(), inboundRequest, DummyRequestDecoder.INSTANCE, Enforcement.DISABLED);
+                    Optional.empty(), inboundRequest, DummyRequestDecoder.INSTANCE, Enforcement.DISABLE);
 
             Optional<Duration> stateDeadline = Deadlines.getRemainingDeadline();
             assertThat(stateDeadline).isPresent();
@@ -238,7 +238,7 @@ class DeadlinesTest {
                     DeadlinesHttpHeaders.EXPECT_WITHIN,
                     Deadlines.durationToHeaderValue(Duration.ofSeconds(2).toNanos()));
             Deadlines.parseFromRequest(
-                    Optional.empty(), inboundRequest, DummyRequestDecoder.INSTANCE, Enforcement.DISABLED);
+                    Optional.empty(), inboundRequest, DummyRequestDecoder.INSTANCE, Enforcement.DISABLE);
 
             Optional<Duration> stateDeadline = Deadlines.getRemainingDeadline();
             assertThat(stateDeadline).isPresent();
@@ -263,7 +263,7 @@ class DeadlinesTest {
                     DeadlinesHttpHeaders.EXPECT_WITHIN,
                     Deadlines.durationToHeaderValue(Duration.ofSeconds(2).toNanos()));
             Deadlines.parseFromRequest(
-                    Optional.empty(), inboundRequest, DummyRequestDecoder.INSTANCE, Enforcement.DISABLED);
+                    Optional.empty(), inboundRequest, DummyRequestDecoder.INSTANCE, Enforcement.DISABLE);
 
             Optional<Duration> stateDeadline = Deadlines.getRemainingDeadline();
             assertThat(stateDeadline).isPresent();
@@ -287,7 +287,7 @@ class DeadlinesTest {
     public void parse_from_request_noop_when_no_header_present() {
         try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
             Map<String, String> request = new HashMap<>();
-            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.DISABLED);
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.DISABLE);
             assertThat(Deadlines.getRemainingDeadline()).isEmpty();
         }
     }
@@ -297,7 +297,7 @@ class DeadlinesTest {
         Map<String, String> request = new HashMap<>();
         Duration providedDeadline = Duration.ofSeconds(1);
         request.put(DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
-        Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.DISABLED);
+        Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.DISABLE);
         assertThat(Deadlines.getRemainingDeadline()).isEmpty();
     }
 
@@ -310,7 +310,7 @@ class DeadlinesTest {
             Duration providedDeadline = Duration.ofMillis(1);
             request.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
-            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.DISABLED);
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.DISABLE);
 
             clock.elapsed += 2_000_000;
 
@@ -328,7 +328,7 @@ class DeadlinesTest {
             Duration providedDeadline = Duration.ofMillis(1);
             request.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
-            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.DISABLED);
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.DISABLE);
 
             clock.elapsed += 2_000_000;
 
@@ -365,7 +365,7 @@ class DeadlinesTest {
             request.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
             Deadlines.parseFromRequest(
-                    Optional.of(Duration.ofMillis(1)), request, DummyRequestDecoder.INSTANCE, Enforcement.DISABLED);
+                    Optional.of(Duration.ofMillis(1)), request, DummyRequestDecoder.INSTANCE, Enforcement.DISABLE);
 
             clock.elapsed += 2_000_000;
             Optional<Duration> remaining = Deadlines.getRemainingDeadline();
@@ -400,7 +400,7 @@ class DeadlinesTest {
             Duration providedDeadline = Duration.ofMillis(1);
             request.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
-            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.DISABLED);
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.DISABLE);
 
             clock.elapsed += 2_000_000;
 
@@ -466,7 +466,7 @@ class DeadlinesTest {
             Duration providedDeadline = Duration.ofMillis(1);
             request.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
-            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.DISABLED);
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.DISABLE);
             // nothing yet...
             assertThat(expiredMeterPropagateIntent.getCount()).isEqualTo(expiredMeterPropagateIntentValue);
             assertThat(expiredMeterPropagateAlreadyExpiredIntent.getCount())
@@ -489,7 +489,7 @@ class DeadlinesTest {
             try (CloseableSpan ignored2 = server2Span.attach()) {
                 expiredMeterPropagateIntentValue = expiredMeterPropagateIntent.getCount();
                 Deadlines.parseFromRequest(
-                        Optional.empty(), outbound1, DummyRequestDecoder.INSTANCE, Enforcement.DISABLED);
+                        Optional.empty(), outbound1, DummyRequestDecoder.INSTANCE, Enforcement.DISABLE);
                 // sending another request when the deadline has already expired should
                 // mark the meter with the "propagate-already-expired" intent
                 expiredMeterPropagateAlreadyExpiredIntentValue = expiredMeterPropagateAlreadyExpiredIntent.getCount();
@@ -512,7 +512,7 @@ class DeadlinesTest {
             Duration providedDeadline = Duration.ofMillis(1);
             request.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
-            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCED);
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCE);
 
             clock.elapsed += 2_000_000;
 
@@ -533,8 +533,7 @@ class DeadlinesTest {
             request.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
             request.put(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "true");
-            Deadlines.parseFromRequest(
-                    Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCED_IF_REQUESTED);
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.DEFER);
 
             clock.elapsed += 2_000_000;
 
@@ -555,7 +554,7 @@ class DeadlinesTest {
             request.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
             request.put(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "false");
-            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCED);
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCE);
 
             clock.elapsed += 2_000_000;
 
@@ -579,7 +578,7 @@ class DeadlinesTest {
             Duration providedDeadline = Duration.ofSeconds(1);
             inbound1.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
-            Deadlines.parseFromRequest(Optional.empty(), inbound1, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCED);
+            Deadlines.parseFromRequest(Optional.empty(), inbound1, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCE);
 
             clock.elapsed += 500_000_000;
 
@@ -589,7 +588,7 @@ class DeadlinesTest {
 
             try (CloseableSpan ignored2 = server2Span.attach()) {
                 Deadlines.parseFromRequest(
-                        Optional.empty(), outbound1, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCED_IF_REQUESTED);
+                        Optional.empty(), outbound1, DummyRequestDecoder.INSTANCE, Enforcement.DEFER);
 
                 clock.elapsed += 600_000_000;
 
@@ -609,8 +608,7 @@ class DeadlinesTest {
             Duration providedDeadline = Duration.ofSeconds(1);
             inbound1.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
-            Deadlines.parseFromRequest(
-                    Optional.empty(), inbound1, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCED_IF_REQUESTED);
+            Deadlines.parseFromRequest(Optional.empty(), inbound1, DummyRequestDecoder.INSTANCE, Enforcement.DEFER);
 
             Map<String, String> outbound = new HashMap<>();
             Deadlines.encodeToRequest(Duration.ofSeconds(10), outbound, DummyRequestEncoder.INSTANCE);
@@ -627,7 +625,7 @@ class DeadlinesTest {
             Duration providedDeadline = Duration.ofSeconds(1);
             inbound1.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
-            Deadlines.parseFromRequest(Optional.empty(), inbound1, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCED);
+            Deadlines.parseFromRequest(Optional.empty(), inbound1, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCE);
 
             Map<String, String> outbound = new HashMap<>();
             Deadlines.encodeToRequest(Duration.ofSeconds(10), outbound, DummyRequestEncoder.INSTANCE);
@@ -645,8 +643,7 @@ class DeadlinesTest {
             inbound1.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
             inbound1.put(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "true");
-            Deadlines.parseFromRequest(
-                    Optional.empty(), inbound1, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCED_IF_REQUESTED);
+            Deadlines.parseFromRequest(Optional.empty(), inbound1, DummyRequestDecoder.INSTANCE, Enforcement.DEFER);
 
             Map<String, String> outbound = new HashMap<>();
             Deadlines.encodeToRequest(Duration.ofSeconds(10), outbound, DummyRequestEncoder.INSTANCE);
@@ -664,7 +661,7 @@ class DeadlinesTest {
             inbound1.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
             inbound1.put(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "false");
-            Deadlines.parseFromRequest(Optional.empty(), inbound1, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCED);
+            Deadlines.parseFromRequest(Optional.empty(), inbound1, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCE);
 
             Map<String, String> outbound = new HashMap<>();
             Deadlines.encodeToRequest(Duration.ofSeconds(10), outbound, DummyRequestEncoder.INSTANCE);
@@ -682,8 +679,7 @@ class DeadlinesTest {
             inbound1.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
             inbound1.put(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "false");
-            Deadlines.parseFromRequest(
-                    Optional.empty(), inbound1, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCED_IF_REQUESTED);
+            Deadlines.parseFromRequest(Optional.empty(), inbound1, DummyRequestDecoder.INSTANCE, Enforcement.DEFER);
 
             Map<String, String> outbound = new HashMap<>();
             Deadlines.encodeToRequest(Duration.ofSeconds(10), outbound, DummyRequestEncoder.INSTANCE);
@@ -699,7 +695,7 @@ class DeadlinesTest {
             Map<String, String> inbound1 = new HashMap<>();
             inbound1.put(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "false");
             Deadlines.parseFromRequest(
-                    Optional.of(Duration.ofSeconds(10)), inbound1, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCED);
+                    Optional.of(Duration.ofSeconds(10)), inbound1, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCE);
 
             Map<String, String> outbound = new HashMap<>();
             Deadlines.encodeToRequest(Duration.ofSeconds(10), outbound, DummyRequestEncoder.INSTANCE);
@@ -715,10 +711,7 @@ class DeadlinesTest {
             Map<String, String> inbound1 = new HashMap<>();
             inbound1.put(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "true");
             Deadlines.parseFromRequest(
-                    Optional.of(Duration.ofSeconds(10)),
-                    inbound1,
-                    DummyRequestDecoder.INSTANCE,
-                    Enforcement.ENFORCED_IF_REQUESTED);
+                    Optional.of(Duration.ofSeconds(10)), inbound1, DummyRequestDecoder.INSTANCE, Enforcement.DEFER);
 
             Map<String, String> outbound = new HashMap<>();
             Deadlines.encodeToRequest(Duration.ofSeconds(10), outbound, DummyRequestEncoder.INSTANCE);
@@ -737,7 +730,7 @@ class DeadlinesTest {
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
             inbound1.put(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "foobar");
             Deadlines.parseFromRequest(
-                    Optional.of(Duration.ofSeconds(10)), inbound1, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCED);
+                    Optional.of(Duration.ofSeconds(10)), inbound1, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCE);
 
             Map<String, String> outbound = new HashMap<>();
             Deadlines.encodeToRequest(Duration.ofSeconds(10), outbound, DummyRequestEncoder.INSTANCE);
@@ -756,10 +749,7 @@ class DeadlinesTest {
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
             inbound1.put(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "foobar");
             Deadlines.parseFromRequest(
-                    Optional.of(Duration.ofSeconds(10)),
-                    inbound1,
-                    DummyRequestDecoder.INSTANCE,
-                    Enforcement.ENFORCED_IF_REQUESTED);
+                    Optional.of(Duration.ofSeconds(10)), inbound1, DummyRequestDecoder.INSTANCE, Enforcement.DEFER);
 
             Map<String, String> outbound = new HashMap<>();
             Deadlines.encodeToRequest(Duration.ofSeconds(10), outbound, DummyRequestEncoder.INSTANCE);

--- a/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
+++ b/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
@@ -18,6 +18,7 @@ package com.palantir.deadlines;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.codahale.metrics.Meter;
 import com.palantir.deadlines.DeadlineMetrics.Expired_Cause;
@@ -197,7 +198,7 @@ class DeadlinesTest {
             Duration providedDeadline = Duration.ofSeconds(1);
             request.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
-            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE);
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, false);
 
             Optional<Duration> remaining = Deadlines.getRemainingDeadline();
             assertThat(remaining).hasValueSatisfying(d -> assertThat(d).isLessThanOrEqualTo(providedDeadline));
@@ -210,7 +211,7 @@ class DeadlinesTest {
             Map<String, String> inboundRequest = new HashMap<>();
             long originalDeadline = Duration.ofSeconds(1).toNanos();
             inboundRequest.put(DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(originalDeadline));
-            Deadlines.parseFromRequest(Optional.empty(), inboundRequest, DummyRequestDecoder.INSTANCE);
+            Deadlines.parseFromRequest(Optional.empty(), inboundRequest, DummyRequestDecoder.INSTANCE, false);
 
             Optional<Duration> stateDeadline = Deadlines.getRemainingDeadline();
             assertThat(stateDeadline).isPresent();
@@ -234,7 +235,7 @@ class DeadlinesTest {
             inboundRequest.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN,
                     Deadlines.durationToHeaderValue(Duration.ofSeconds(2).toNanos()));
-            Deadlines.parseFromRequest(Optional.empty(), inboundRequest, DummyRequestDecoder.INSTANCE);
+            Deadlines.parseFromRequest(Optional.empty(), inboundRequest, DummyRequestDecoder.INSTANCE, false);
 
             Optional<Duration> stateDeadline = Deadlines.getRemainingDeadline();
             assertThat(stateDeadline).isPresent();
@@ -258,7 +259,7 @@ class DeadlinesTest {
             inboundRequest.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN,
                     Deadlines.durationToHeaderValue(Duration.ofSeconds(2).toNanos()));
-            Deadlines.parseFromRequest(Optional.empty(), inboundRequest, DummyRequestDecoder.INSTANCE);
+            Deadlines.parseFromRequest(Optional.empty(), inboundRequest, DummyRequestDecoder.INSTANCE, false);
 
             Optional<Duration> stateDeadline = Deadlines.getRemainingDeadline();
             assertThat(stateDeadline).isPresent();
@@ -282,7 +283,7 @@ class DeadlinesTest {
     public void parse_from_request_noop_when_no_header_present() {
         try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
             Map<String, String> request = new HashMap<>();
-            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE);
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, false);
             assertThat(Deadlines.getRemainingDeadline()).isEmpty();
         }
     }
@@ -292,7 +293,7 @@ class DeadlinesTest {
         Map<String, String> request = new HashMap<>();
         Duration providedDeadline = Duration.ofSeconds(1);
         request.put(DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
-        Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE);
+        Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, false);
         assertThat(Deadlines.getRemainingDeadline()).isEmpty();
     }
 
@@ -305,7 +306,7 @@ class DeadlinesTest {
             Duration providedDeadline = Duration.ofMillis(1);
             request.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
-            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE);
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, false);
 
             clock.elapsed += 2_000_000;
 
@@ -323,7 +324,7 @@ class DeadlinesTest {
             Duration providedDeadline = Duration.ofMillis(1);
             request.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
-            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE);
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, false);
 
             clock.elapsed += 2_000_000;
 
@@ -359,7 +360,7 @@ class DeadlinesTest {
             Duration providedDeadline = Duration.ofMillis(100);
             request.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
-            Deadlines.parseFromRequest(Optional.of(Duration.ofMillis(1)), request, DummyRequestDecoder.INSTANCE);
+            Deadlines.parseFromRequest(Optional.of(Duration.ofMillis(1)), request, DummyRequestDecoder.INSTANCE, false);
 
             clock.elapsed += 2_000_000;
             Optional<Duration> remaining = Deadlines.getRemainingDeadline();
@@ -394,7 +395,7 @@ class DeadlinesTest {
             Duration providedDeadline = Duration.ofMillis(1);
             request.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
-            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE);
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, false);
 
             clock.elapsed += 2_000_000;
 
@@ -452,21 +453,22 @@ class DeadlinesTest {
                     .intent(Expired_Intent.PROPAGATE_ALREADY_EXPIRED)
                     .build();
 
+            long expiredMeterPropagateIntentValue = expiredMeterPropagateIntent.getCount();
+            long expiredMeterPropagateAlreadyExpiredIntentValue = expiredMeterPropagateAlreadyExpiredIntent.getCount();
+
             // the first hop receives a valid, non-zero deadline on the wire
             Map<String, String> request = new HashMap<>();
             Duration providedDeadline = Duration.ofMillis(1);
             request.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
-            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE);
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, false);
             // nothing yet...
-            assertThat(expiredMeterPropagateIntent.getCount()).isZero();
-            assertThat(expiredMeterPropagateAlreadyExpiredIntent.getCount()).isZero();
+            assertThat(expiredMeterPropagateIntent.getCount()).isEqualTo(expiredMeterPropagateIntentValue);
+            assertThat(expiredMeterPropagateAlreadyExpiredIntent.getCount())
+                    .isEqualTo(expiredMeterPropagateAlreadyExpiredIntentValue);
 
             // force expiration within the first hop
             clock.elapsed += 2_000_000;
-
-            long expiredMeterPropagateIntentValue = expiredMeterPropagateIntent.getCount();
-            long expiredMeterPropagateAlreadyExpiredIntentValue = expiredMeterPropagateAlreadyExpiredIntent.getCount();
 
             Map<String, String> outbound1 = new HashMap<>();
             Deadlines.encodeToRequest(Duration.ofSeconds(10), outbound1, DummyRequestEncoder.INSTANCE);
@@ -481,7 +483,7 @@ class DeadlinesTest {
             // next hop parses a zero deadline
             try (CloseableSpan ignored2 = server2Span.attach()) {
                 expiredMeterPropagateIntentValue = expiredMeterPropagateIntent.getCount();
-                Deadlines.parseFromRequest(Optional.empty(), outbound1, DummyRequestDecoder.INSTANCE);
+                Deadlines.parseFromRequest(Optional.empty(), outbound1, DummyRequestDecoder.INSTANCE, false);
                 // sending another request when the deadline has already expired should
                 // mark the meter with the "propagate-already-expired" intent
                 expiredMeterPropagateAlreadyExpiredIntentValue = expiredMeterPropagateAlreadyExpiredIntent.getCount();
@@ -491,6 +493,101 @@ class DeadlinesTest {
                         .isGreaterThan(expiredMeterPropagateAlreadyExpiredIntentValue);
                 // meter with the "propagate" intent is unchanged
                 assertThat(expiredMeterPropagateIntent.getCount()).isEqualTo(expiredMeterPropagateIntentValue);
+            }
+        }
+    }
+
+    @Test
+    public void test_external_deadline_expiration_is_enforced_by_internal_flag() {
+        TestClock clock = new TestClock();
+        Deadlines.setClock(clock);
+        try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
+            Map<String, String> request = new HashMap<>();
+            Duration providedDeadline = Duration.ofMillis(1);
+            request.put(
+                    DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, true);
+
+            clock.elapsed += 2_000_000;
+
+            Map<String, String> outbound = new HashMap<>();
+            assertThatThrownBy(() ->
+                            Deadlines.encodeToRequest(Duration.ofSeconds(5), outbound, DummyRequestEncoder.INSTANCE))
+                    .isInstanceOf(DeadlineExpiredException.External.class);
+        }
+    }
+
+    @Test
+    public void test_external_deadline_expiration_is_enforced_by_external_flag() {
+        TestClock clock = new TestClock();
+        Deadlines.setClock(clock);
+        try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
+            Map<String, String> request = new HashMap<>();
+            Duration providedDeadline = Duration.ofMillis(1);
+            request.put(
+                    DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
+            request.put(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "true");
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, false);
+
+            clock.elapsed += 2_000_000;
+
+            Map<String, String> outbound = new HashMap<>();
+            assertThatThrownBy(() ->
+                            Deadlines.encodeToRequest(Duration.ofSeconds(5), outbound, DummyRequestEncoder.INSTANCE))
+                    .isInstanceOf(DeadlineExpiredException.External.class);
+        }
+    }
+
+    @Test
+    public void test_external_deadline_expiration_is_not_enforced_when_external_flag_is_not_true() {
+        TestClock clock = new TestClock();
+        Deadlines.setClock(clock);
+        try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
+            Map<String, String> request = new HashMap<>();
+            Duration providedDeadline = Duration.ofMillis(1);
+            request.put(
+                    DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
+            request.put(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "false");
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, false);
+
+            clock.elapsed += 2_000_000;
+
+            Map<String, String> outbound = new HashMap<>();
+            Deadlines.encodeToRequest(Duration.ofSeconds(5), outbound, DummyRequestEncoder.INSTANCE);
+            assertThat(outbound).containsExactlyEntriesOf(Map.of(DeadlinesHttpHeaders.EXPECT_WITHIN, "0"));
+        }
+    }
+
+    @Test
+    public void test_enforcement_flag_is_propagated_and_enforced_at_next_hop() {
+        TestClock clock = new TestClock();
+        Deadlines.setClock(clock);
+
+        DetachedSpan server1Span = DetachedSpan.start("server1");
+        DetachedSpan server2Span = DetachedSpan.start("server2");
+
+        try (CloseableSpan ignored = server1Span.attach()) {
+            Map<String, String> inbound1 = new HashMap<>();
+            Duration providedDeadline = Duration.ofSeconds(1);
+            inbound1.put(
+                    DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
+            Deadlines.parseFromRequest(Optional.empty(), inbound1, DummyRequestDecoder.INSTANCE, true);
+
+            clock.elapsed += 500_000_000;
+
+            Map<String, String> outbound1 = new HashMap<>();
+            Deadlines.encodeToRequest(Duration.ofSeconds(10), outbound1, DummyRequestEncoder.INSTANCE);
+            assertThat(outbound1).containsEntry(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "true");
+
+            try (CloseableSpan ignored2 = server2Span.attach()) {
+                Deadlines.parseFromRequest(Optional.empty(), outbound1, DummyRequestDecoder.INSTANCE, false);
+
+                clock.elapsed += 600_000_000;
+
+                Map<String, String> outbound2 = new HashMap<>();
+                assertThatThrownBy(() -> Deadlines.encodeToRequest(
+                                Duration.ofSeconds(10), outbound2, DummyRequestEncoder.INSTANCE))
+                        .isInstanceOf(DeadlineExpiredException.External.class);
             }
         }
     }

--- a/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
+++ b/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
@@ -440,6 +440,39 @@ class DeadlinesTest {
     }
 
     @Test
+    public void disable_propagation_does_not_enforce_deadline_expiration() {
+        // ensures that a call to disableFurtherDeadlinePropagation means that future calls to encodeToRequest
+        // do not enforce deadline expiration even if they originally would have
+        TestClock clock = new TestClock();
+        Deadlines.setClock(clock);
+        try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
+            Map<String, String> request = new HashMap<>();
+            Duration providedDeadline = Duration.ofSeconds(1);
+            request.put(
+                    DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCE);
+
+            clock.elapsed += 500_000_000;
+
+            Map<String, String> outbound1 = new HashMap<>();
+            Deadlines.encodeToRequest(Duration.ofSeconds(10), outbound1, DummyRequestEncoder.INSTANCE);
+
+            assertThat(outbound1).containsEntry(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "true");
+
+            Deadlines.disableFurtherDeadlinePropagation();
+
+            // now expired
+            clock.elapsed += 1_000_000_000;
+
+            Map<String, String> outbound2 = new HashMap<>();
+            // should not throw
+            Deadlines.encodeToRequest(Duration.ofSeconds(10), outbound2, DummyRequestEncoder.INSTANCE);
+
+            assertThat(outbound2).isEmpty();
+        }
+    }
+
+    @Test
     public void multihop_expired_received_deadline_marks_propagate_already_expired_meter() {
         TestClock clock = new TestClock();
         Deadlines.setClock(clock);

--- a/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
+++ b/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.codahale.metrics.Meter;
 import com.palantir.deadlines.DeadlineMetrics.Expired_Cause;
 import com.palantir.deadlines.DeadlineMetrics.Expired_Intent;
+import com.palantir.deadlines.Deadlines.Enforcement;
 import com.palantir.deadlines.Deadlines.RequestDecodingAdapter;
 import com.palantir.deadlines.Deadlines.RequestEncodingAdapter;
 import com.palantir.tracing.CloseableSpan;
@@ -198,7 +199,7 @@ class DeadlinesTest {
             Duration providedDeadline = Duration.ofSeconds(1);
             request.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
-            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, false);
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.IGNORED);
 
             Optional<Duration> remaining = Deadlines.getRemainingDeadline();
             assertThat(remaining).hasValueSatisfying(d -> assertThat(d).isLessThanOrEqualTo(providedDeadline));
@@ -211,7 +212,8 @@ class DeadlinesTest {
             Map<String, String> inboundRequest = new HashMap<>();
             long originalDeadline = Duration.ofSeconds(1).toNanos();
             inboundRequest.put(DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(originalDeadline));
-            Deadlines.parseFromRequest(Optional.empty(), inboundRequest, DummyRequestDecoder.INSTANCE, false);
+            Deadlines.parseFromRequest(
+                    Optional.empty(), inboundRequest, DummyRequestDecoder.INSTANCE, Enforcement.IGNORED);
 
             Optional<Duration> stateDeadline = Deadlines.getRemainingDeadline();
             assertThat(stateDeadline).isPresent();
@@ -235,7 +237,8 @@ class DeadlinesTest {
             inboundRequest.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN,
                     Deadlines.durationToHeaderValue(Duration.ofSeconds(2).toNanos()));
-            Deadlines.parseFromRequest(Optional.empty(), inboundRequest, DummyRequestDecoder.INSTANCE, false);
+            Deadlines.parseFromRequest(
+                    Optional.empty(), inboundRequest, DummyRequestDecoder.INSTANCE, Enforcement.IGNORED);
 
             Optional<Duration> stateDeadline = Deadlines.getRemainingDeadline();
             assertThat(stateDeadline).isPresent();
@@ -259,7 +262,8 @@ class DeadlinesTest {
             inboundRequest.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN,
                     Deadlines.durationToHeaderValue(Duration.ofSeconds(2).toNanos()));
-            Deadlines.parseFromRequest(Optional.empty(), inboundRequest, DummyRequestDecoder.INSTANCE, false);
+            Deadlines.parseFromRequest(
+                    Optional.empty(), inboundRequest, DummyRequestDecoder.INSTANCE, Enforcement.IGNORED);
 
             Optional<Duration> stateDeadline = Deadlines.getRemainingDeadline();
             assertThat(stateDeadline).isPresent();
@@ -283,7 +287,7 @@ class DeadlinesTest {
     public void parse_from_request_noop_when_no_header_present() {
         try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
             Map<String, String> request = new HashMap<>();
-            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, false);
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.IGNORED);
             assertThat(Deadlines.getRemainingDeadline()).isEmpty();
         }
     }
@@ -293,7 +297,7 @@ class DeadlinesTest {
         Map<String, String> request = new HashMap<>();
         Duration providedDeadline = Duration.ofSeconds(1);
         request.put(DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
-        Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, false);
+        Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.IGNORED);
         assertThat(Deadlines.getRemainingDeadline()).isEmpty();
     }
 
@@ -306,7 +310,7 @@ class DeadlinesTest {
             Duration providedDeadline = Duration.ofMillis(1);
             request.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
-            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, false);
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.IGNORED);
 
             clock.elapsed += 2_000_000;
 
@@ -324,7 +328,7 @@ class DeadlinesTest {
             Duration providedDeadline = Duration.ofMillis(1);
             request.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
-            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, false);
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.IGNORED);
 
             clock.elapsed += 2_000_000;
 
@@ -360,7 +364,8 @@ class DeadlinesTest {
             Duration providedDeadline = Duration.ofMillis(100);
             request.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
-            Deadlines.parseFromRequest(Optional.of(Duration.ofMillis(1)), request, DummyRequestDecoder.INSTANCE, false);
+            Deadlines.parseFromRequest(
+                    Optional.of(Duration.ofMillis(1)), request, DummyRequestDecoder.INSTANCE, Enforcement.IGNORED);
 
             clock.elapsed += 2_000_000;
             Optional<Duration> remaining = Deadlines.getRemainingDeadline();
@@ -395,7 +400,7 @@ class DeadlinesTest {
             Duration providedDeadline = Duration.ofMillis(1);
             request.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
-            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, false);
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.IGNORED);
 
             clock.elapsed += 2_000_000;
 
@@ -461,7 +466,7 @@ class DeadlinesTest {
             Duration providedDeadline = Duration.ofMillis(1);
             request.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
-            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, false);
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.IGNORED);
             // nothing yet...
             assertThat(expiredMeterPropagateIntent.getCount()).isEqualTo(expiredMeterPropagateIntentValue);
             assertThat(expiredMeterPropagateAlreadyExpiredIntent.getCount())
@@ -483,7 +488,8 @@ class DeadlinesTest {
             // next hop parses a zero deadline
             try (CloseableSpan ignored2 = server2Span.attach()) {
                 expiredMeterPropagateIntentValue = expiredMeterPropagateIntent.getCount();
-                Deadlines.parseFromRequest(Optional.empty(), outbound1, DummyRequestDecoder.INSTANCE, false);
+                Deadlines.parseFromRequest(
+                        Optional.empty(), outbound1, DummyRequestDecoder.INSTANCE, Enforcement.IGNORED);
                 // sending another request when the deadline has already expired should
                 // mark the meter with the "propagate-already-expired" intent
                 expiredMeterPropagateAlreadyExpiredIntentValue = expiredMeterPropagateAlreadyExpiredIntent.getCount();
@@ -506,7 +512,7 @@ class DeadlinesTest {
             Duration providedDeadline = Duration.ofMillis(1);
             request.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
-            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, true);
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCED);
 
             clock.elapsed += 2_000_000;
 
@@ -527,7 +533,8 @@ class DeadlinesTest {
             request.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
             request.put(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "true");
-            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, false);
+            Deadlines.parseFromRequest(
+                    Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCED_IF_REQUESTED);
 
             clock.elapsed += 2_000_000;
 
@@ -548,13 +555,18 @@ class DeadlinesTest {
             request.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
             request.put(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "false");
-            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, false);
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCED);
 
             clock.elapsed += 2_000_000;
 
             Map<String, String> outbound = new HashMap<>();
             Deadlines.encodeToRequest(Duration.ofSeconds(5), outbound, DummyRequestEncoder.INSTANCE);
-            assertThat(outbound).containsExactlyEntriesOf(Map.of(DeadlinesHttpHeaders.EXPECT_WITHIN, "0"));
+            assertThat(outbound)
+                    .containsExactlyEntriesOf(Map.of(
+                            DeadlinesHttpHeaders.EXPECT_WITHIN,
+                            "0",
+                            DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED,
+                            "false"));
         }
     }
 
@@ -571,7 +583,7 @@ class DeadlinesTest {
             Duration providedDeadline = Duration.ofSeconds(1);
             inbound1.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
-            Deadlines.parseFromRequest(Optional.empty(), inbound1, DummyRequestDecoder.INSTANCE, true);
+            Deadlines.parseFromRequest(Optional.empty(), inbound1, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCED);
 
             clock.elapsed += 500_000_000;
 
@@ -580,7 +592,8 @@ class DeadlinesTest {
             assertThat(outbound1).containsEntry(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "true");
 
             try (CloseableSpan ignored2 = server2Span.attach()) {
-                Deadlines.parseFromRequest(Optional.empty(), outbound1, DummyRequestDecoder.INSTANCE, false);
+                Deadlines.parseFromRequest(
+                        Optional.empty(), outbound1, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCED_IF_REQUESTED);
 
                 clock.elapsed += 600_000_000;
 

--- a/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
+++ b/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
@@ -199,7 +199,7 @@ class DeadlinesTest {
             Duration providedDeadline = Duration.ofSeconds(1);
             request.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
-            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.IGNORED);
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.DISABLED);
 
             Optional<Duration> remaining = Deadlines.getRemainingDeadline();
             assertThat(remaining).hasValueSatisfying(d -> assertThat(d).isLessThanOrEqualTo(providedDeadline));
@@ -213,7 +213,7 @@ class DeadlinesTest {
             long originalDeadline = Duration.ofSeconds(1).toNanos();
             inboundRequest.put(DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(originalDeadline));
             Deadlines.parseFromRequest(
-                    Optional.empty(), inboundRequest, DummyRequestDecoder.INSTANCE, Enforcement.IGNORED);
+                    Optional.empty(), inboundRequest, DummyRequestDecoder.INSTANCE, Enforcement.DISABLED);
 
             Optional<Duration> stateDeadline = Deadlines.getRemainingDeadline();
             assertThat(stateDeadline).isPresent();
@@ -238,7 +238,7 @@ class DeadlinesTest {
                     DeadlinesHttpHeaders.EXPECT_WITHIN,
                     Deadlines.durationToHeaderValue(Duration.ofSeconds(2).toNanos()));
             Deadlines.parseFromRequest(
-                    Optional.empty(), inboundRequest, DummyRequestDecoder.INSTANCE, Enforcement.IGNORED);
+                    Optional.empty(), inboundRequest, DummyRequestDecoder.INSTANCE, Enforcement.DISABLED);
 
             Optional<Duration> stateDeadline = Deadlines.getRemainingDeadline();
             assertThat(stateDeadline).isPresent();
@@ -263,7 +263,7 @@ class DeadlinesTest {
                     DeadlinesHttpHeaders.EXPECT_WITHIN,
                     Deadlines.durationToHeaderValue(Duration.ofSeconds(2).toNanos()));
             Deadlines.parseFromRequest(
-                    Optional.empty(), inboundRequest, DummyRequestDecoder.INSTANCE, Enforcement.IGNORED);
+                    Optional.empty(), inboundRequest, DummyRequestDecoder.INSTANCE, Enforcement.DISABLED);
 
             Optional<Duration> stateDeadline = Deadlines.getRemainingDeadline();
             assertThat(stateDeadline).isPresent();
@@ -287,7 +287,7 @@ class DeadlinesTest {
     public void parse_from_request_noop_when_no_header_present() {
         try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
             Map<String, String> request = new HashMap<>();
-            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.IGNORED);
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.DISABLED);
             assertThat(Deadlines.getRemainingDeadline()).isEmpty();
         }
     }
@@ -297,7 +297,7 @@ class DeadlinesTest {
         Map<String, String> request = new HashMap<>();
         Duration providedDeadline = Duration.ofSeconds(1);
         request.put(DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
-        Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.IGNORED);
+        Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.DISABLED);
         assertThat(Deadlines.getRemainingDeadline()).isEmpty();
     }
 
@@ -310,7 +310,7 @@ class DeadlinesTest {
             Duration providedDeadline = Duration.ofMillis(1);
             request.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
-            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.IGNORED);
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.DISABLED);
 
             clock.elapsed += 2_000_000;
 
@@ -328,7 +328,7 @@ class DeadlinesTest {
             Duration providedDeadline = Duration.ofMillis(1);
             request.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
-            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.IGNORED);
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.DISABLED);
 
             clock.elapsed += 2_000_000;
 
@@ -365,7 +365,7 @@ class DeadlinesTest {
             request.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
             Deadlines.parseFromRequest(
-                    Optional.of(Duration.ofMillis(1)), request, DummyRequestDecoder.INSTANCE, Enforcement.IGNORED);
+                    Optional.of(Duration.ofMillis(1)), request, DummyRequestDecoder.INSTANCE, Enforcement.DISABLED);
 
             clock.elapsed += 2_000_000;
             Optional<Duration> remaining = Deadlines.getRemainingDeadline();
@@ -400,7 +400,7 @@ class DeadlinesTest {
             Duration providedDeadline = Duration.ofMillis(1);
             request.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
-            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.IGNORED);
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.DISABLED);
 
             clock.elapsed += 2_000_000;
 
@@ -466,7 +466,7 @@ class DeadlinesTest {
             Duration providedDeadline = Duration.ofMillis(1);
             request.put(
                     DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
-            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.IGNORED);
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.DISABLED);
             // nothing yet...
             assertThat(expiredMeterPropagateIntent.getCount()).isEqualTo(expiredMeterPropagateIntentValue);
             assertThat(expiredMeterPropagateAlreadyExpiredIntent.getCount())
@@ -489,7 +489,7 @@ class DeadlinesTest {
             try (CloseableSpan ignored2 = server2Span.attach()) {
                 expiredMeterPropagateIntentValue = expiredMeterPropagateIntent.getCount();
                 Deadlines.parseFromRequest(
-                        Optional.empty(), outbound1, DummyRequestDecoder.INSTANCE, Enforcement.IGNORED);
+                        Optional.empty(), outbound1, DummyRequestDecoder.INSTANCE, Enforcement.DISABLED);
                 // sending another request when the deadline has already expired should
                 // mark the meter with the "propagate-already-expired" intent
                 expiredMeterPropagateAlreadyExpiredIntentValue = expiredMeterPropagateAlreadyExpiredIntent.getCount();
@@ -561,12 +561,8 @@ class DeadlinesTest {
 
             Map<String, String> outbound = new HashMap<>();
             Deadlines.encodeToRequest(Duration.ofSeconds(5), outbound, DummyRequestEncoder.INSTANCE);
-            assertThat(outbound)
-                    .containsExactlyEntriesOf(Map.of(
-                            DeadlinesHttpHeaders.EXPECT_WITHIN,
-                            "0",
-                            DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED,
-                            "false"));
+            assertThat(outbound).containsEntry(DeadlinesHttpHeaders.EXPECT_WITHIN, "0");
+            assertThat(outbound).containsEntry(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "false");
         }
     }
 
@@ -606,7 +602,8 @@ class DeadlinesTest {
     }
 
     @Test
-    public void test_enforcement_not_disabled_when_absent() {
+    public void test_propagate_enforcement_defer() {
+        // first hop receives no enforcement flag, and uses strategy ENFORCED_IF_REQUESTED => DEFER
         try (CloseableTracer ignored = CloseableTracer.startSpan("test")) {
             Map<String, String> inbound1 = new HashMap<>();
             Duration providedDeadline = Duration.ofSeconds(1);
@@ -615,8 +612,149 @@ class DeadlinesTest {
             Deadlines.parseFromRequest(
                     Optional.empty(), inbound1, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCED_IF_REQUESTED);
 
-            // enforcement wasn't explicitly enabled or disabled at this hop; we should exclude the enforcement flag
-            // from outbound requests as well
+            Map<String, String> outbound = new HashMap<>();
+            Deadlines.encodeToRequest(Duration.ofSeconds(10), outbound, DummyRequestEncoder.INSTANCE);
+
+            assertThat(outbound).doesNotContainKey(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED);
+        }
+    }
+
+    @Test
+    public void test_propagate_enforcement_enforce_from_local() {
+        // first hop receives no enforcement flag, but uses strategy ENFORCED => ENFORCE
+        try (CloseableTracer ignored = CloseableTracer.startSpan("test")) {
+            Map<String, String> inbound1 = new HashMap<>();
+            Duration providedDeadline = Duration.ofSeconds(1);
+            inbound1.put(
+                    DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
+            Deadlines.parseFromRequest(Optional.empty(), inbound1, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCED);
+
+            Map<String, String> outbound = new HashMap<>();
+            Deadlines.encodeToRequest(Duration.ofSeconds(10), outbound, DummyRequestEncoder.INSTANCE);
+
+            assertThat(outbound).containsEntry(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "true");
+        }
+    }
+
+    @Test
+    public void test_propagate_enforcement_enforce_from_external() {
+        // first hop receives `Expect-Within-Enforced: true` and uses strategy ENFORCED_IF_REQUESTED => ENFORCE
+        try (CloseableTracer ignored = CloseableTracer.startSpan("test")) {
+            Map<String, String> inbound1 = new HashMap<>();
+            Duration providedDeadline = Duration.ofSeconds(1);
+            inbound1.put(
+                    DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
+            inbound1.put(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "true");
+            Deadlines.parseFromRequest(
+                    Optional.empty(), inbound1, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCED_IF_REQUESTED);
+
+            Map<String, String> outbound = new HashMap<>();
+            Deadlines.encodeToRequest(Duration.ofSeconds(10), outbound, DummyRequestEncoder.INSTANCE);
+
+            assertThat(outbound).containsEntry(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "true");
+        }
+    }
+
+    @Test
+    public void test_propagate_enforcement_disable_from_external_local_enforced() {
+        // first hop receives `Expect-Within-Enforced: false` and uses strategy ENFORCED => DISABLE
+        try (CloseableTracer ignored = CloseableTracer.startSpan("test")) {
+            Map<String, String> inbound1 = new HashMap<>();
+            Duration providedDeadline = Duration.ofSeconds(1);
+            inbound1.put(
+                    DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
+            inbound1.put(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "false");
+            Deadlines.parseFromRequest(Optional.empty(), inbound1, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCED);
+
+            Map<String, String> outbound = new HashMap<>();
+            Deadlines.encodeToRequest(Duration.ofSeconds(10), outbound, DummyRequestEncoder.INSTANCE);
+
+            assertThat(outbound).containsEntry(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "false");
+        }
+    }
+
+    @Test
+    public void test_propagate_enforcement_disable_from_external_local_deferred() {
+        // first hop receives `Expect-Within-Enforced: false` and uses strategy ENFORCED_IF_REQUESTED => DISABLE
+        try (CloseableTracer ignored = CloseableTracer.startSpan("test")) {
+            Map<String, String> inbound1 = new HashMap<>();
+            Duration providedDeadline = Duration.ofSeconds(1);
+            inbound1.put(
+                    DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
+            inbound1.put(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "false");
+            Deadlines.parseFromRequest(
+                    Optional.empty(), inbound1, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCED_IF_REQUESTED);
+
+            Map<String, String> outbound = new HashMap<>();
+            Deadlines.encodeToRequest(Duration.ofSeconds(10), outbound, DummyRequestEncoder.INSTANCE);
+
+            assertThat(outbound).containsEntry(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "false");
+        }
+    }
+
+    @Test
+    public void test_propagate_enforcement_missing_deadline_local_enforced() {
+        // ensure that when the `Expect-Within` header is missing, the external `Expect-Within-Enforced` flag is ignored
+        try (CloseableTracer ignored = CloseableTracer.startSpan("test")) {
+            Map<String, String> inbound1 = new HashMap<>();
+            inbound1.put(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "false");
+            Deadlines.parseFromRequest(
+                    Optional.of(Duration.ofSeconds(10)), inbound1, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCED);
+
+            Map<String, String> outbound = new HashMap<>();
+            Deadlines.encodeToRequest(Duration.ofSeconds(10), outbound, DummyRequestEncoder.INSTANCE);
+
+            assertThat(outbound).containsEntry(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "true");
+        }
+    }
+
+    @Test
+    public void test_propagate_enforcement_missing_deadline_local_deferred() {
+        // ensure that when the `Expect-Within` header is missing, the external `Expect-Within-Enforced` flag is ignored
+        try (CloseableTracer ignored = CloseableTracer.startSpan("test")) {
+            Map<String, String> inbound1 = new HashMap<>();
+            inbound1.put(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "true");
+            Deadlines.parseFromRequest(
+                    Optional.of(Duration.ofSeconds(10)),
+                    inbound1,
+                    DummyRequestDecoder.INSTANCE,
+                    Enforcement.ENFORCED_IF_REQUESTED);
+
+            Map<String, String> outbound = new HashMap<>();
+            Deadlines.encodeToRequest(Duration.ofSeconds(10), outbound, DummyRequestEncoder.INSTANCE);
+
+            assertThat(outbound).doesNotContainKey(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED);
+        }
+    }
+
+    @Test
+    public void test_propagate_enforcement_bogus_external_flag_local_enforced() {
+        // ensure that when the `Expect-Within-Enforced` flag contains an unknown value, it is ignored
+        try (CloseableTracer ignored = CloseableTracer.startSpan("test")) {
+            Map<String, String> inbound1 = new HashMap<>();
+            inbound1.put(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "foobar");
+            Deadlines.parseFromRequest(
+                    Optional.of(Duration.ofSeconds(10)), inbound1, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCED);
+
+            Map<String, String> outbound = new HashMap<>();
+            Deadlines.encodeToRequest(Duration.ofSeconds(10), outbound, DummyRequestEncoder.INSTANCE);
+
+            assertThat(outbound).containsEntry(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "true");
+        }
+    }
+
+    @Test
+    public void test_propagate_enforcement_bogus_external_flag_local_deferred() {
+        // ensure that when the `Expect-Within-Enforced` flag contains an unknown value, it is ignored
+        try (CloseableTracer ignored = CloseableTracer.startSpan("test")) {
+            Map<String, String> inbound1 = new HashMap<>();
+            inbound1.put(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "foobar");
+            Deadlines.parseFromRequest(
+                    Optional.of(Duration.ofSeconds(10)),
+                    inbound1,
+                    DummyRequestDecoder.INSTANCE,
+                    Enforcement.ENFORCED_IF_REQUESTED);
+
             Map<String, String> outbound = new HashMap<>();
             Deadlines.encodeToRequest(Duration.ofSeconds(10), outbound, DummyRequestEncoder.INSTANCE);
 

--- a/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
+++ b/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
@@ -605,6 +605,25 @@ class DeadlinesTest {
         }
     }
 
+    @Test
+    public void test_enforcement_not_disabled_when_absent() {
+        try (CloseableTracer ignored = CloseableTracer.startSpan("test")) {
+            Map<String, String> inbound1 = new HashMap<>();
+            Duration providedDeadline = Duration.ofSeconds(1);
+            inbound1.put(
+                    DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
+            Deadlines.parseFromRequest(
+                    Optional.empty(), inbound1, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCED_IF_REQUESTED);
+
+            // enforcement wasn't explicitly enabled or disabled at this hop; we should exclude the enforcement flag
+            // from outbound requests as well
+            Map<String, String> outbound = new HashMap<>();
+            Deadlines.encodeToRequest(Duration.ofSeconds(10), outbound, DummyRequestEncoder.INSTANCE);
+
+            assertThat(outbound).doesNotContainKey(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED);
+        }
+    }
+
     private enum DummyRequestEncoder implements RequestEncodingAdapter<Map<String, String>> {
         INSTANCE;
 


### PR DESCRIPTION
Allows receivers to optionally enforce a parsed deadline, and propagate that enforcement flag further along the RPC call chain.

`Deadlines.parseFromRequest` takes an optional `enforcementStrategy` flag, which may be either `ENFORCE`, `DEFER`, or `DISABLE`:
- when set to `ENFORCE`, expirations will be enforced by this node (an exception will be thrown by `encodeToRequest` if the deadline has expired) and an `Expect-Within-Enforced: true` header will be added to future outbound requests
- when set to `DEFER`, expirations are enforced only if we received an `Expect-Within-Enforced: true` when parsing request headers. Future calls to `encodeToRequest` will only append an `Expect-Within-Enforced: true` if this flag was parsed on the inbound request first.
- when set to `DISABLE`, expirations are not enforced and we will also set `Expect-Within-Enforced: false` on future outbound requests to additionally disable enforcement on downstream nodes
- if `Expect-Within-Enforced: false` is parsed from request headers, it will disable enforcement regardless of the value of `enforcementStrategy`. This is to ensure that `DISABLE` can be propagated further down the RPC call chain no matter what, if necessary

Replaces #34 and #80.
