### PR TITLE
deadline.expired metric reports a "throw" intent

### DIFF
--- a/changelog/@unreleased/pr-162.v2.yml
+++ b/changelog/@unreleased/pr-162.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: deadline.expired metric reports a "throw" intent
+  links:
+  - https://github.com/palantir/deadlines-java/pull/162

--- a/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
@@ -340,13 +340,23 @@ public final class Deadlines {
         if (deadline <= 0) {
             // expired
             Expired_Cause cause = internal ? Expired_Cause.INTERNAL : Expired_Cause.EXTERNAL;
-            Expired_Intent intent = enforced ? Expired_Intent.THROW : Expired_Intent.PROPAGATE;
-            if (disablePropagation) {
-                intent = Expired_Intent.IGNORE;
-            } else if (alreadyExpired) {
-                intent = Expired_Intent.PROPAGATE_ALREADY_EXPIRED;
+            Expired_Intent intent;
+            if (enforced) {
+                // intent is always "throw" if enforced = true, regardless of what the other flags are
+                intent = Expired_Intent.THROW;
+            } else {
+                // will not throw, report one of the other intents
+                if (disablePropagation) {
+                    intent = Expired_Intent.IGNORE;
+                } else if (alreadyExpired) {
+                    intent = Expired_Intent.PROPAGATE_ALREADY_EXPIRED;
+                } else {
+                    intent = Expired_Intent.PROPAGATE;
+                }
             }
+
             metrics.expired().cause(cause).intent(intent).build().mark();
+
             if (enforced) {
                 throw internal ? DeadlineExpiredException.internal() : DeadlineExpiredException.external();
             }

--- a/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
@@ -340,13 +340,11 @@ public final class Deadlines {
         if (deadline <= 0) {
             // expired
             Expired_Cause cause = internal ? Expired_Cause.INTERNAL : Expired_Cause.EXTERNAL;
-            Expired_Intent intent = Expired_Intent.PROPAGATE;
+            Expired_Intent intent = enforced ? Expired_Intent.THROW : Expired_Intent.PROPAGATE;
             if (disablePropagation) {
                 intent = Expired_Intent.IGNORE;
             } else if (alreadyExpired) {
                 intent = Expired_Intent.PROPAGATE_ALREADY_EXPIRED;
-            } else if (enforced) {
-                intent = Expired_Intent.THROW;
             }
             metrics.expired().cause(cause).intent(intent).build().mark();
             if (enforced) {

--- a/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
@@ -345,6 +345,8 @@ public final class Deadlines {
                 intent = Expired_Intent.IGNORE;
             } else if (alreadyExpired) {
                 intent = Expired_Intent.PROPAGATE_ALREADY_EXPIRED;
+            } else if (enforced) {
+                intent = Expired_Intent.THROW;
             }
             metrics.expired().cause(cause).intent(intent).build().mark();
             if (enforced) {

--- a/deadlines/src/main/metrics/deadlines-metrics.yml
+++ b/deadlines/src/main/metrics/deadlines-metrics.yml
@@ -22,6 +22,9 @@ namespaces:
             docs: Describes the intent (or not) to propagate an expired deadline on
                  further RPC calls.
             values:
+              - value: throw
+                docs: Enforcement was enabled for this trace at the time the deadline
+                      expiration was reached, and an exception was thrown.
               - value: propagate
                 docs: Deadline propagation was enabled for this trace at the time
                       the deadline expiration was reached. This means that further

--- a/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
+++ b/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
@@ -537,6 +537,35 @@ class DeadlinesTest {
     }
 
     @Test
+    public void test_enforced_deadline_expiration_reports_throw_intent_metric() {
+        TestClock clock = new TestClock();
+        Deadlines.setClock(clock);
+        try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
+            Map<String, String> request = new HashMap<>();
+            Duration providedDeadline = Duration.ofMillis(1);
+            request.put(
+                    DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCE);
+
+            clock.elapsed += 2_000_000;
+
+            // additionally validate that the expired deadline meter is marked with the "THROW" intent
+            DeadlineMetrics metrics = DeadlineMetrics.of(SharedTaggedMetricRegistries.getSingleton());
+            Meter externalMeter = metrics.expired()
+                    .cause(Expired_Cause.EXTERNAL)
+                    .intent(Expired_Intent.THROW)
+                    .build();
+            long originalExternalValue = externalMeter.getCount();
+
+            Map<String, String> outbound = new HashMap<>();
+            assertThatThrownBy(() ->
+                            Deadlines.encodeToRequest(Duration.ofSeconds(5), outbound, DummyRequestEncoder.INSTANCE))
+                    .isInstanceOf(DeadlineExpiredException.External.class);
+            assertThat(externalMeter.getCount()).isGreaterThan(originalExternalValue);
+        }
+    }
+
+    @Test
     public void test_external_deadline_expiration_is_enforced_by_internal_flag() {
         TestClock clock = new TestClock();
         Deadlines.setClock(clock);


### PR DESCRIPTION
This is distinguished from "propagate", and indicates that an exception will be thrown because enforcement was enabled (whereas "propagate" marks the meter to indicate a deadline expiration, but does _not_ throw an exception).

This is useful for distinguishing codepaths that hit a deadline expiration causing the caller to receive an exception, versus ones that allow `encodeToRequest` to succeed while only reporting a metric indicating that the deadline had expired.