### PR TITLE
implement scoped deadlines

### DIFF
--- a/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
@@ -21,6 +21,7 @@ import com.google.common.base.CharMatcher;
 import com.google.common.base.Strings;
 import com.google.common.util.concurrent.RateLimiter;
 import com.google.errorprone.annotations.InlineMe;
+import com.google.errorprone.annotations.MustBeClosed;
 import com.palantir.deadlines.DeadlineMetrics.Expired_Cause;
 import com.palantir.deadlines.DeadlineMetrics.Expired_Intent;
 import com.palantir.logsafe.SafeArg;
@@ -44,6 +45,8 @@ public final class Deadlines {
 
     private static final TraceLocal<ProvidedDeadline> deadlineState = TraceLocal.of();
 
+    private static final ThreadLocal<ProvidedDeadline> threadLocalOverride = new ThreadLocal<>();
+
     @SuppressWarnings("for-rollout:deprecation")
     private static final DeadlineMetrics metrics = DeadlineMetrics.of(SharedTaggedMetricRegistries.getSingleton());
 
@@ -60,12 +63,17 @@ public final class Deadlines {
      * {@link Duration#ZERO} is returned.
      * <p>
      * If no deadline state has been set for the current trace, return an empty Optional.
+     * <p>
+     * If the current thread is within a {@link ScopedDeadline} created by {@link #withDeadline(Duration, Enforcement)}
+     * or {@link #withoutDeadline()}, the scoped deadline will be used instead of the TraceLocal state.
      *
      * @return the remaining deadline time for the current trace, or {@link Duration#ZERO} if the deadline
      * has expired, or {@link Optional#empty()} if no such deadline state exists.
      */
     public static Optional<Duration> getRemainingDeadline() {
-        ProvidedDeadline stateDeadline = deadlineState.get();
+        // Check thread-local override first
+        ProvidedDeadline override = threadLocalOverride.get();
+        ProvidedDeadline stateDeadline = override != null ? override : deadlineState.get();
         if (stateDeadline == null) {
             return Optional.empty();
         }
@@ -102,6 +110,99 @@ public final class Deadlines {
     }
 
     /**
+     * Execute a code block with an alternative deadline, ignoring the current TraceLocal state.
+     * <p>
+     * The alternative deadline will only affect the current thread for the duration of the
+     * returned scope. When the scope closes, the thread reverts to using the TraceLocal state.
+     * <p>
+     * This is useful when you need to execute an operation with a different deadline than the
+     * one currently in effect for the trace. For example, you might want to give a retry operation
+     * a shorter deadline than the overall request deadline.
+     * <p>
+     * Example usage:
+     * <pre>
+     * try (var scope = Deadlines.withDeadline(Duration.ofSeconds(5), Enforcement.ENFORCE)) {
+     *     // This operation uses the 5-second deadline regardless of TraceLocal state
+     *     service.performOperation();
+     * }
+     * // Back to TraceLocal state
+     * </pre>
+     *
+     * @param deadline the alternative deadline duration
+     * @param enforcement the enforcement strategy for the alternative deadline
+     * @return a ScopedDeadline that must be closed to restore previous state
+     * @see #withDeadline(Duration)
+     */
+    @MustBeClosed
+    public static ScopedDeadline withDeadline(Duration deadline, Enforcement enforcement) {
+        long deadlineNanos = deadline.toNanos();
+        ProvidedDeadline override = new ProvidedDeadline(deadlineNanos, getClockNanoTime(), true, false, enforcement);
+        return new ThreadLocalScopedDeadline(override);
+    }
+
+    /**
+     * Execute a code block with an alternative deadline, inheriting the enforcement strategy
+     * from the current TraceLocal state.
+     * <p>
+     * This overload provides a convenient way to set a different deadline duration while
+     * preserving the enforcement strategy that's currently in effect. If there is no deadline
+     * state in the TraceLocal, the enforcement strategy defaults to {@link Enforcement#DEFER}.
+     * <p>
+     * The alternative deadline will only affect the current thread for the duration of the
+     * returned scope. When the scope closes, the thread reverts to using the TraceLocal state.
+     * <p>
+     * Example usage:
+     * <pre>
+     * try (ScopedDeadline scope = Deadlines.withDeadline(Duration.ofSeconds(5))) {
+     *     // This operation uses the 5-second deadline with the current enforcement strategy
+     *     service.performOperation();
+     * }
+     * // Back to TraceLocal state
+     * </pre>
+     *
+     * @param deadline the alternative deadline duration
+     * @return a ScopedDeadline that must be closed to restore previous state
+     * @see #withDeadline(Duration, Enforcement)
+     */
+    @MustBeClosed
+    public static ScopedDeadline withDeadline(Duration deadline) {
+        // Determine enforcement from TraceLocal state, or default to DEFER
+        ProvidedDeadline traceLocalState = deadlineState.get();
+        Enforcement enforcement = traceLocalState != null ? traceLocalState.enforcement() : Enforcement.DEFER;
+        return withDeadline(deadline, enforcement);
+    }
+
+    /**
+     * Execute a code block without deadline constraints, ignoring the current TraceLocal state.
+     * <p>
+     * This is useful for operations that should never be subject to deadline enforcement,
+     * such as cleanup routines or logging operations that must complete regardless of the
+     * deadline state.
+     * <p>
+     * When this scope is active, calls to {@link #getRemainingDeadline()} will return
+     * {@link Optional#empty()}, and calls to {@link #encodeToRequest} will not propagate
+     * deadline information to downstream services.
+     * <p>
+     * Example usage:
+     * <pre>
+     * try (var scope = Deadlines.withoutDeadline()) {
+     *     // Cleanup operation not subject to deadlines
+     *     cleanupService.performCleanup();
+     * }
+     * // Back to TraceLocal state
+     * </pre>
+     *
+     * @return a ScopedDeadline that must be closed to restore previous state
+     */
+    @MustBeClosed
+    public static ScopedDeadline withoutDeadline() {
+        // Use a special marker: disablePropagation=true means "no deadline"
+        ProvidedDeadline override =
+                new ProvidedDeadline(Long.MAX_VALUE, getClockNanoTime(), true, true, Enforcement.DISABLE);
+        return new ThreadLocalScopedDeadline(override);
+    }
+
+    /**
      * Encode a deadline into a request header.
      * <p>
      * The actual deadline value encoded will be the minimum of:
@@ -111,6 +212,9 @@ public final class Deadlines {
      * already-set internal state, or a smaller one if the caller chooses that.
      * <p>
      * This function has no side effects on the internal deadline state stored in a TraceLocal.
+     * <p>
+     * If the current thread is within a {@link ScopedDeadline} created by {@link #withDeadline(Duration, Enforcement)}
+     * or {@link #withoutDeadline()}, the scoped deadline will be used instead of the TraceLocal state.
      * <p>
      * The client requested enforcement strategy will be resolved against the internal state in the following manner:
      *   - If either client or internal state requests {@link Enforcement#DISABLE}, then the deadline is not enforced.
@@ -130,7 +234,9 @@ public final class Deadlines {
             T request,
             RequestEncodingAdapter<? super T> adapter,
             Enforcement clientEnforcement) {
-        ProvidedDeadline stateDeadline = deadlineState.get();
+        // Check thread-local override first
+        ProvidedDeadline override = threadLocalOverride.get();
+        ProvidedDeadline stateDeadline = override != null ? override : deadlineState.get();
         long proposedDeadlineNanos = proposedDeadline.toNanos();
         if (stateDeadline == null) {
             // use proposedDeadline
@@ -480,5 +586,39 @@ public final class Deadlines {
 
     interface Clock {
         long nanoTime();
+    }
+
+    /**
+     * A scope that temporarily overrides the deadline state for the current thread.
+     * <p>
+     * Instances of this type are returned by {@link #withDeadline(Duration, Enforcement)} and
+     * {@link #withoutDeadline()}. The scope must be closed to restore the previous deadline state.
+     * <p>
+     * Instances of this type are designed for use with try-with-resources:
+     * <pre>
+     * try (ScopedDeadline scope = Deadlines.withDeadline(Duration.ofSeconds(5), Enforcement.ENFORCE)) {
+     *     // code here uses the alternative deadline
+     * }
+     * // previous deadline state restored
+     * </pre>
+     */
+    public interface ScopedDeadline extends AutoCloseable {
+        @Override
+        void close();
+    }
+
+    private static final class ThreadLocalScopedDeadline implements ScopedDeadline {
+        @Nullable
+        private final ProvidedDeadline previousOverride;
+
+        ThreadLocalScopedDeadline(@Nullable ProvidedDeadline newOverride) {
+            this.previousOverride = threadLocalOverride.get();
+            threadLocalOverride.set(newOverride);
+        }
+
+        @Override
+        public void close() {
+            threadLocalOverride.set(previousOverride);
+        }
     }
 }

--- a/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
+++ b/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
@@ -958,6 +958,356 @@ class DeadlinesTest {
         }
     }
 
+    // Tests for scoped deadline overrides (withDeadline and withoutDeadline)
+
+    @Test
+    void withDeadline_overrides_trace_local_state() {
+        try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
+            // Set up TraceLocal state with 10 second deadline
+            Map<String, String> request = new HashMap<>();
+            request.put(
+                    DeadlinesHttpHeaders.EXPECT_WITHIN,
+                    Deadlines.durationToHeaderValue(Duration.ofSeconds(10).toNanos()));
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.DEFER);
+
+            assertThat(Deadlines.getRemainingDeadline()).isPresent();
+
+            // Override with 5 second deadline
+            try (Deadlines.ScopedDeadline scope = Deadlines.withDeadline(Duration.ofSeconds(5), Enforcement.ENFORCE)) {
+                Optional<Duration> remaining = Deadlines.getRemainingDeadline();
+                assertThat(remaining).isPresent();
+                assertThat(remaining.get()).isLessThanOrEqualTo(Duration.ofSeconds(5));
+                assertThat(remaining.get()).isGreaterThan(Duration.ofSeconds(4));
+            }
+
+            // After scope closes, TraceLocal state is restored
+            Optional<Duration> remaining = Deadlines.getRemainingDeadline();
+            assertThat(remaining).isPresent();
+            assertThat(remaining.get()).isGreaterThan(Duration.ofSeconds(9));
+        }
+    }
+
+    @Test
+    void withoutDeadline_disables_deadline_enforcement() {
+        try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
+            // Set up TraceLocal state with deadline
+            Map<String, String> request = new HashMap<>();
+            request.put(
+                    DeadlinesHttpHeaders.EXPECT_WITHIN,
+                    Deadlines.durationToHeaderValue(Duration.ofSeconds(10).toNanos()));
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCE);
+
+            assertThat(Deadlines.getRemainingDeadline()).isPresent();
+
+            // withoutDeadline should disable deadline
+            try (Deadlines.ScopedDeadline scope = Deadlines.withoutDeadline()) {
+                assertThat(Deadlines.getRemainingDeadline()).isEmpty();
+            }
+
+            // After scope closes, TraceLocal state is restored
+            assertThat(Deadlines.getRemainingDeadline()).isPresent();
+        }
+    }
+
+    @Test
+    void withDeadline_encodeToRequest_uses_override() {
+        try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
+            // Set up TraceLocal state with 10 second deadline
+            Map<String, String> inbound = new HashMap<>();
+            inbound.put(
+                    DeadlinesHttpHeaders.EXPECT_WITHIN,
+                    Deadlines.durationToHeaderValue(Duration.ofSeconds(10).toNanos()));
+            Deadlines.parseFromRequest(Optional.empty(), inbound, DummyRequestDecoder.INSTANCE, Enforcement.DEFER);
+
+            // Override with 2 second deadline
+            try (Deadlines.ScopedDeadline scope = Deadlines.withDeadline(Duration.ofSeconds(2), Enforcement.ENFORCE)) {
+                Map<String, String> outbound = new HashMap<>();
+                Deadlines.encodeToRequest(
+                        Duration.ofSeconds(5), outbound, DummyRequestEncoder.INSTANCE, Enforcement.DEFER);
+
+                // Should use the minimum of override (2s) and proposed (5s) = 2s
+                Long encoded = Deadlines.tryParseSecondsToNanoseconds(outbound.get(DeadlinesHttpHeaders.EXPECT_WITHIN));
+                assertThat(encoded)
+                        .isNotNull()
+                        .isLessThanOrEqualTo(Duration.ofSeconds(2).toNanos());
+                assertThat(outbound).containsEntry(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "true");
+            }
+        }
+    }
+
+    @Test
+    void withoutDeadline_encodeToRequest_does_not_propagate() {
+        try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
+            // Set up TraceLocal state with deadline
+            Map<String, String> inbound = new HashMap<>();
+            inbound.put(
+                    DeadlinesHttpHeaders.EXPECT_WITHIN,
+                    Deadlines.durationToHeaderValue(Duration.ofSeconds(10).toNanos()));
+            Deadlines.parseFromRequest(Optional.empty(), inbound, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCE);
+
+            // withoutDeadline should prevent propagation
+            try (Deadlines.ScopedDeadline scope = Deadlines.withoutDeadline()) {
+                Map<String, String> outbound = new HashMap<>();
+                Deadlines.encodeToRequest(
+                        Duration.ofSeconds(5), outbound, DummyRequestEncoder.INSTANCE, Enforcement.DEFER);
+
+                // Should not encode any deadline headers
+                assertThat(outbound).isEmpty();
+            }
+        }
+    }
+
+    @Test
+    void withDeadline_enforces_expired_deadline() {
+        TestClock clock = new TestClock();
+        Deadlines.setClock(clock);
+        try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
+            // Override with very short deadline
+            try (Deadlines.ScopedDeadline scope = Deadlines.withDeadline(Duration.ofMillis(1), Enforcement.ENFORCE)) {
+                clock.elapsed += 2_000_000; // 2ms elapsed
+
+                Map<String, String> outbound = new HashMap<>();
+                assertThatExceptionOfType(DeadlineExpiredException.Internal.class)
+                        .isThrownBy(() -> Deadlines.encodeToRequest(
+                                Duration.ofSeconds(5), outbound, DummyRequestEncoder.INSTANCE, Enforcement.DEFER));
+            }
+        }
+    }
+
+    @Test
+    void withDeadline_scope_restored_on_exception() {
+        try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
+            // Set up TraceLocal state
+            Map<String, String> request = new HashMap<>();
+            request.put(
+                    DeadlinesHttpHeaders.EXPECT_WITHIN,
+                    Deadlines.durationToHeaderValue(Duration.ofSeconds(10).toNanos()));
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.DEFER);
+
+            Duration originalRemaining = Deadlines.getRemainingDeadline().orElseThrow();
+
+            // Override with deadline and throw exception
+            assertThatThrownBy(() -> {
+                        try (Deadlines.ScopedDeadline scope =
+                                Deadlines.withDeadline(Duration.ofSeconds(1), Enforcement.ENFORCE)) {
+                            throw new RuntimeException("test exception");
+                        }
+                    })
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("test exception");
+
+            // TraceLocal state should be restored
+            Duration restoredRemaining = Deadlines.getRemainingDeadline().orElseThrow();
+            assertThat(restoredRemaining.toMillis()).isGreaterThanOrEqualTo(originalRemaining.toMillis() - 100);
+        }
+    }
+
+    @Test
+    void withDeadline_works_without_trace_context() {
+        // No trace context - TraceLocal is empty
+        assertThat(Deadlines.getRemainingDeadline()).isEmpty();
+
+        // Override should still work
+        try (Deadlines.ScopedDeadline scope = Deadlines.withDeadline(Duration.ofSeconds(5), Enforcement.ENFORCE)) {
+            Optional<Duration> remaining = Deadlines.getRemainingDeadline();
+            assertThat(remaining).isPresent();
+            assertThat(remaining.get()).isLessThanOrEqualTo(Duration.ofSeconds(5));
+        }
+
+        // After scope closes, should be empty again
+        assertThat(Deadlines.getRemainingDeadline()).isEmpty();
+    }
+
+    @Test
+    void withDeadline_thread_isolation() throws Exception {
+        try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
+            // Set up TraceLocal state with 10 second deadline
+            Map<String, String> request = new HashMap<>();
+            request.put(
+                    DeadlinesHttpHeaders.EXPECT_WITHIN,
+                    Deadlines.durationToHeaderValue(Duration.ofSeconds(10).toNanos()));
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.DEFER);
+
+            // Create override in main thread
+            try (Deadlines.ScopedDeadline scope = Deadlines.withDeadline(Duration.ofSeconds(2), Enforcement.ENFORCE)) {
+                Duration mainThreadDeadline = Deadlines.getRemainingDeadline().orElseThrow();
+                assertThat(mainThreadDeadline).isLessThanOrEqualTo(Duration.ofSeconds(2));
+
+                // Check deadline in a different thread (not part of the trace)
+                Thread thread = new Thread(() -> {
+                    // Other thread should not see the override (no trace context)
+                    assertThat(Deadlines.getRemainingDeadline()).isEmpty();
+                });
+                thread.start();
+                thread.join();
+
+                // Main thread should still have override
+                Duration stillOverridden = Deadlines.getRemainingDeadline().orElseThrow();
+                assertThat(stillOverridden).isLessThanOrEqualTo(Duration.ofSeconds(2));
+            }
+        }
+    }
+
+    @Test
+    @SuppressWarnings("NestedTryDepth")
+    void withDeadline_nested_scopes_handled_gracefully() {
+        try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
+            // Set up TraceLocal state
+            Map<String, String> request = new HashMap<>();
+            request.put(
+                    DeadlinesHttpHeaders.EXPECT_WITHIN,
+                    Deadlines.durationToHeaderValue(Duration.ofSeconds(10).toNanos()));
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.DEFER);
+
+            // Outer scope with 5 second deadline
+            try (Deadlines.ScopedDeadline outerScope =
+                    Deadlines.withDeadline(Duration.ofSeconds(5), Enforcement.ENFORCE)) {
+                Duration outerDeadline = Deadlines.getRemainingDeadline().orElseThrow();
+                assertThat(outerDeadline).isLessThanOrEqualTo(Duration.ofSeconds(5));
+
+                // Inner scope with 2 second deadline
+                try (Deadlines.ScopedDeadline innerScope =
+                        Deadlines.withDeadline(Duration.ofSeconds(2), Enforcement.DEFER)) {
+                    Duration innerDeadline = Deadlines.getRemainingDeadline().orElseThrow();
+                    assertThat(innerDeadline).isLessThanOrEqualTo(Duration.ofSeconds(2));
+                }
+
+                // After inner scope closes, outer scope is restored
+                Duration restoredOuter = Deadlines.getRemainingDeadline().orElseThrow();
+                assertThat(restoredOuter).isLessThanOrEqualTo(Duration.ofSeconds(5));
+            }
+
+            // After outer scope closes, TraceLocal is restored
+            Duration restoredTraceLocal = Deadlines.getRemainingDeadline().orElseThrow();
+            assertThat(restoredTraceLocal).isGreaterThan(Duration.ofSeconds(9));
+        }
+    }
+
+    @Test
+    void withDeadline_can_be_called_multiple_times_idempotent_close() {
+        try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
+            assertThatCode(() -> {
+                        try (Deadlines.ScopedDeadline scope =
+                                Deadlines.withDeadline(Duration.ofSeconds(5), Enforcement.ENFORCE)) {
+                            scope.close();
+                        } // Second close should be safe (idempotent)
+                    })
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    // Tests for withDeadline(Duration) overload that inherits enforcement
+
+    @Test
+    void withDeadline_single_param_inherits_enforce_from_trace_local() {
+        try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
+            // Set up TraceLocal with ENFORCE strategy
+            Map<String, String> inbound = new HashMap<>();
+            inbound.put(
+                    DeadlinesHttpHeaders.EXPECT_WITHIN,
+                    Deadlines.durationToHeaderValue(Duration.ofSeconds(10).toNanos()));
+            inbound.put(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "true");
+            Deadlines.parseFromRequest(Optional.empty(), inbound, DummyRequestDecoder.INSTANCE, Enforcement.DEFER);
+
+            // Use single-parameter withDeadline - should inherit ENFORCE
+            try (Deadlines.ScopedDeadline scope = Deadlines.withDeadline(Duration.ofSeconds(5))) {
+                Map<String, String> outbound = new HashMap<>();
+                Deadlines.encodeToRequest(
+                        Duration.ofSeconds(10), outbound, DummyRequestEncoder.INSTANCE, Enforcement.DEFER);
+
+                // Should have ENFORCE strategy (from TraceLocal)
+                assertThat(outbound).containsEntry(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "true");
+            }
+        }
+    }
+
+    @Test
+    void withDeadline_single_param_inherits_defer_from_trace_local() {
+        try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
+            // Set up TraceLocal with DEFER strategy (no enforcement header)
+            Map<String, String> inbound = new HashMap<>();
+            inbound.put(
+                    DeadlinesHttpHeaders.EXPECT_WITHIN,
+                    Deadlines.durationToHeaderValue(Duration.ofSeconds(10).toNanos()));
+            Deadlines.parseFromRequest(Optional.empty(), inbound, DummyRequestDecoder.INSTANCE, Enforcement.DEFER);
+
+            // Use single-parameter withDeadline - should inherit DEFER
+            try (Deadlines.ScopedDeadline scope = Deadlines.withDeadline(Duration.ofSeconds(5))) {
+                Map<String, String> outbound = new HashMap<>();
+                Deadlines.encodeToRequest(
+                        Duration.ofSeconds(10), outbound, DummyRequestEncoder.INSTANCE, Enforcement.DEFER);
+
+                // Should NOT have enforcement header (DEFER)
+                assertThat(outbound).doesNotContainKey(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED);
+            }
+        }
+    }
+
+    @Test
+    void withDeadline_single_param_inherits_disable_from_trace_local() {
+        try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
+            // Set up TraceLocal with DISABLE strategy
+            Map<String, String> inbound = new HashMap<>();
+            inbound.put(
+                    DeadlinesHttpHeaders.EXPECT_WITHIN,
+                    Deadlines.durationToHeaderValue(Duration.ofSeconds(10).toNanos()));
+            inbound.put(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "false");
+            Deadlines.parseFromRequest(Optional.empty(), inbound, DummyRequestDecoder.INSTANCE, Enforcement.DEFER);
+
+            // Use single-parameter withDeadline - should inherit DISABLE
+            try (Deadlines.ScopedDeadline scope = Deadlines.withDeadline(Duration.ofSeconds(5))) {
+                Map<String, String> outbound = new HashMap<>();
+                Deadlines.encodeToRequest(
+                        Duration.ofSeconds(10), outbound, DummyRequestEncoder.INSTANCE, Enforcement.DEFER);
+
+                // Should have DISABLE strategy (false)
+                assertThat(outbound).containsEntry(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "false");
+            }
+        }
+    }
+
+    @Test
+    void withDeadline_single_param_defaults_to_defer_when_no_trace_local() {
+        // No trace context - TraceLocal is empty
+        assertThat(Deadlines.getRemainingDeadline()).isEmpty();
+
+        // Use single-parameter withDeadline - should default to DEFER
+        try (Deadlines.ScopedDeadline scope = Deadlines.withDeadline(Duration.ofSeconds(5))) {
+            Map<String, String> outbound = new HashMap<>();
+            Deadlines.encodeToRequest(
+                    Duration.ofSeconds(10), outbound, DummyRequestEncoder.INSTANCE, Enforcement.DEFER);
+
+            // Should NOT have enforcement header (defaults to DEFER)
+            assertThat(outbound).doesNotContainKey(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED);
+        }
+    }
+
+    @Test
+    void withDeadline_single_param_respects_inherited_enforcement_on_expiration() {
+        TestClock clock = new TestClock();
+        Deadlines.setClock(clock);
+        try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
+            // Set up TraceLocal with ENFORCE strategy
+            Map<String, String> inbound = new HashMap<>();
+            inbound.put(
+                    DeadlinesHttpHeaders.EXPECT_WITHIN,
+                    Deadlines.durationToHeaderValue(Duration.ofSeconds(10).toNanos()));
+            inbound.put(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "true");
+            Deadlines.parseFromRequest(Optional.empty(), inbound, DummyRequestDecoder.INSTANCE, Enforcement.DEFER);
+
+            // Use single-parameter withDeadline with very short deadline
+            try (Deadlines.ScopedDeadline scope = Deadlines.withDeadline(Duration.ofMillis(1))) {
+                clock.elapsed += 2_000_000; // 2ms elapsed
+
+                Map<String, String> outbound = new HashMap<>();
+                // Should throw because inherited ENFORCE and deadline expired
+                assertThatExceptionOfType(DeadlineExpiredException.Internal.class)
+                        .isThrownBy(() -> Deadlines.encodeToRequest(
+                                Duration.ofSeconds(10), outbound, DummyRequestEncoder.INSTANCE, Enforcement.DEFER));
+            }
+        }
+    }
+
     private enum DummyRequestEncoder implements RequestEncodingAdapter<Map<String, String>> {
         INSTANCE;
 


### PR DESCRIPTION
Allow overriding deadline state temporarily within a try-with-resources block. This implementation uses a ThreadLocal, and can only change the deadline state for the calling thread, so care should be taken to limit uses to scenarios where a single thread must run a small operation with an alternate deadline. Other threads will be unaffected.

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

