### PR TITLE
provide query method for configured enforcement

### DIFF
--- a/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
@@ -77,6 +77,25 @@ public final class Deadlines {
     }
 
     /**
+     * Get the enforcement strategy for the current deadline.
+     * <p>
+     * Queries the current deadline state from a TraceLocal, and returns the {@link Enforcement}
+     * strategy that was configured when the deadline was parsed or set.
+     * <p>
+     * If no deadline state has been set for the current trace, return an empty Optional.
+     *
+     * @return the enforcement strategy for the current trace, or {@link Optional#empty()} if no such
+     * deadline state exists.
+     */
+    public static Optional<Enforcement> getEnforcement() {
+        ProvidedDeadline stateDeadline = deadlineState.get();
+        if (stateDeadline == null) {
+            return Optional.empty();
+        }
+        return Optional.of(stateDeadline.enforcement());
+    }
+
+    /**
      * Disables propagation of deadline values any further for the current trace.
      * <p>
      * Callers can use this to short-circuit deadline propagation from the current trace when they are sure that

--- a/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
@@ -88,11 +88,7 @@ public final class Deadlines {
      * deadline state exists.
      */
     public static Optional<Enforcement> getEnforcement() {
-        ProvidedDeadline stateDeadline = deadlineState.get();
-        if (stateDeadline == null) {
-            return Optional.empty();
-        }
-        return Optional.of(stateDeadline.enforcement());
+        return Optional.ofNullable(deadlineState.get()).map(ProvidedDeadline::enforcement);
     }
 
     /**

--- a/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
+++ b/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
@@ -958,6 +958,93 @@ class DeadlinesTest {
         }
     }
 
+    @Test
+    void get_enforcement_returns_empty_when_no_deadline_state() {
+        try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
+            assertThat(Deadlines.getEnforcement()).isEmpty();
+        }
+    }
+
+    @Test
+    void get_enforcement_returns_enforce_when_parsed_with_enforce_strategy() {
+        try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
+            Map<String, String> request = new HashMap<>();
+            request.put(
+                    DeadlinesHttpHeaders.EXPECT_WITHIN,
+                    Deadlines.durationToHeaderValue(Duration.ofSeconds(1).toNanos()));
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCE);
+
+            assertThat(Deadlines.getEnforcement()).contains(Enforcement.ENFORCE);
+        }
+    }
+
+    @Test
+    void get_enforcement_returns_defer_when_parsed_with_defer_strategy() {
+        try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
+            Map<String, String> request = new HashMap<>();
+            request.put(
+                    DeadlinesHttpHeaders.EXPECT_WITHIN,
+                    Deadlines.durationToHeaderValue(Duration.ofSeconds(1).toNanos()));
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.DEFER);
+
+            assertThat(Deadlines.getEnforcement()).contains(Enforcement.DEFER);
+        }
+    }
+
+    @Test
+    void get_enforcement_returns_disable_when_parsed_with_disable_strategy() {
+        try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
+            Map<String, String> request = new HashMap<>();
+            request.put(
+                    DeadlinesHttpHeaders.EXPECT_WITHIN,
+                    Deadlines.durationToHeaderValue(Duration.ofSeconds(1).toNanos()));
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.DISABLE);
+
+            assertThat(Deadlines.getEnforcement()).contains(Enforcement.DISABLE);
+        }
+    }
+
+    @Test
+    void get_enforcement_returns_enforce_when_header_requests_enforcement() {
+        try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
+            Map<String, String> request = new HashMap<>();
+            request.put(
+                    DeadlinesHttpHeaders.EXPECT_WITHIN,
+                    Deadlines.durationToHeaderValue(Duration.ofSeconds(1).toNanos()));
+            request.put(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "true");
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.DEFER);
+
+            assertThat(Deadlines.getEnforcement()).contains(Enforcement.ENFORCE);
+        }
+    }
+
+    @Test
+    void get_enforcement_returns_disable_when_header_disables_enforcement() {
+        try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
+            Map<String, String> request = new HashMap<>();
+            request.put(
+                    DeadlinesHttpHeaders.EXPECT_WITHIN,
+                    Deadlines.durationToHeaderValue(Duration.ofSeconds(1).toNanos()));
+            request.put(DeadlinesHttpHeaders.EXPECT_WITHIN_ENFORCED, "false");
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCE);
+
+            // Even though local strategy is ENFORCE, header "false" should override to DISABLE
+            assertThat(Deadlines.getEnforcement()).contains(Enforcement.DISABLE);
+        }
+    }
+
+    @Test
+    void get_enforcement_returns_empty_when_no_trace() {
+        Map<String, String> request = new HashMap<>();
+        request.put(
+                DeadlinesHttpHeaders.EXPECT_WITHIN,
+                Deadlines.durationToHeaderValue(Duration.ofSeconds(1).toNanos()));
+        Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.ENFORCE);
+
+        // Without a trace, deadline state won't be set
+        assertThat(Deadlines.getEnforcement()).isEmpty();
+    }
+
     private enum DummyRequestEncoder implements RequestEncodingAdapter<Map<String, String>> {
         INSTANCE;
 


### PR DESCRIPTION
## Before this PR
Cannot query the current enforcement state.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
provide query method for configured enforcement
==COMMIT_MSG==

## Possible downsides?
Unclear if this is particularly useful to callers. We expand the API surface by adding this, and probably can't take it back after this. But it's a read-only method that doesn't really affect much.
