### PR TITLE
Adds a metric for initial deadline budget on expiry

### DIFF
--- a/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
@@ -387,6 +387,12 @@ public final class Deadlines {
 
             metrics.expired().cause(cause).intent(intent).build().mark();
 
+            // Record the original deadline budget we were given. If state exists, use the original
+            // value stored at parse time; otherwise the deadline arg itself is the original budget.
+            ProvidedDeadline state = deadlineState.get();
+            long originalBudgetNanos = state != null ? state.valueNanos() : deadline;
+            metrics.expiredBudget().update(originalBudgetNanos);
+
             if (enforced) {
                 throw internal ? DeadlineExpiredException.internal() : DeadlineExpiredException.external();
             }

--- a/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
@@ -387,15 +387,33 @@ public final class Deadlines {
 
             metrics.expired().cause(cause).intent(intent).build().mark();
 
-            // Record the original deadline budget we were given. If state exists, use the original
+            // Record the original deadline budget bucket. If state exists, use the original
             // value stored at parse time; otherwise the deadline arg itself is the original budget.
             ProvidedDeadline state = deadlineState.get();
             long originalBudgetNanos = state != null ? state.valueNanos() : deadline;
-            metrics.expiredBudget().update(originalBudgetNanos);
+            metrics.expiredBudget(budgetBucket(originalBudgetNanos)).mark();
 
             if (enforced) {
                 throw internal ? DeadlineExpiredException.internal() : DeadlineExpiredException.external();
             }
+        }
+    }
+
+    private static DeadlineMetrics.ExpiredBudget_Bucket budgetBucket(long nanos) {
+        if (nanos < 1_000_000L) {
+            return DeadlineMetrics.ExpiredBudget_Bucket.SUB_1MS;
+        } else if (nanos < 10_000_000L) {
+            return DeadlineMetrics.ExpiredBudget_Bucket.SUB_10MS;
+        } else if (nanos < 100_000_000L) {
+            return DeadlineMetrics.ExpiredBudget_Bucket.SUB_100MS;
+        } else if (nanos < 1_000_000_000L) {
+            return DeadlineMetrics.ExpiredBudget_Bucket.SUB_1S;
+        } else if (nanos < 10_000_000_000L) {
+            return DeadlineMetrics.ExpiredBudget_Bucket.SUB_10S;
+        } else if (nanos < 100_000_000_000L) {
+            return DeadlineMetrics.ExpiredBudget_Bucket.SUB_100S;
+        } else {
+            return DeadlineMetrics.ExpiredBudget_Bucket.ABOVE_100S;
         }
     }
 

--- a/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
+++ b/deadlines/src/main/java/com/palantir/deadlines/Deadlines.java
@@ -385,13 +385,17 @@ public final class Deadlines {
                 }
             }
 
-            metrics.expired().cause(cause).intent(intent).build().mark();
-
             // Record the original deadline budget bucket. If state exists, use the original
             // value stored at parse time; otherwise the deadline arg itself is the original budget.
             ProvidedDeadline state = deadlineState.get();
             long originalBudgetNanos = state != null ? state.valueNanos() : deadline;
-            metrics.expiredBudget(budgetBucket(originalBudgetNanos)).mark();
+
+            metrics.expired()
+                    .cause(cause)
+                    .intent(intent)
+                    .budget(budgetBucket(originalBudgetNanos))
+                    .build()
+                    .mark();
 
             if (enforced) {
                 throw internal ? DeadlineExpiredException.internal() : DeadlineExpiredException.external();
@@ -399,21 +403,17 @@ public final class Deadlines {
         }
     }
 
-    private static DeadlineMetrics.ExpiredBudget_Bucket budgetBucket(long nanos) {
-        if (nanos < 1_000_000L) {
-            return DeadlineMetrics.ExpiredBudget_Bucket.SUB_1MS;
-        } else if (nanos < 10_000_000L) {
-            return DeadlineMetrics.ExpiredBudget_Bucket.SUB_10MS;
-        } else if (nanos < 100_000_000L) {
-            return DeadlineMetrics.ExpiredBudget_Bucket.SUB_100MS;
+    private static DeadlineMetrics.Expired_Budget budgetBucket(long nanos) {
+        if (nanos < 100_000_000L) {
+            return DeadlineMetrics.Expired_Budget.SUB_100MS;
         } else if (nanos < 1_000_000_000L) {
-            return DeadlineMetrics.ExpiredBudget_Bucket.SUB_1S;
+            return DeadlineMetrics.Expired_Budget.SUB_1S;
         } else if (nanos < 10_000_000_000L) {
-            return DeadlineMetrics.ExpiredBudget_Bucket.SUB_10S;
+            return DeadlineMetrics.Expired_Budget.SUB_10S;
         } else if (nanos < 100_000_000_000L) {
-            return DeadlineMetrics.ExpiredBudget_Bucket.SUB_100S;
+            return DeadlineMetrics.Expired_Budget.SUB_100S;
         } else {
-            return DeadlineMetrics.ExpiredBudget_Bucket.ABOVE_100S;
+            return DeadlineMetrics.Expired_Budget.ABOVE_100S;
         }
     }
 

--- a/deadlines/src/main/metrics/deadlines-metrics.yml
+++ b/deadlines/src/main/metrics/deadlines-metrics.yml
@@ -39,6 +39,23 @@ namespaces:
                       RPC calls will not propagate an expired deadline value any more.
         docs: Marked every time a deadline expiration is reached
       expired.budget:
-        type: histogram
-        docs: Records the original deadline budget (in nanoseconds) that was provided
-              to this service at the time of a deadline expiration.
+        type: meter
+        tags:
+          - name: bucket
+            values:
+              - value: sub-1ms
+                docs: Original deadline budget was less than 1 millisecond.
+              - value: sub-10ms
+                docs: Original deadline budget was less than 10 milliseconds.
+              - value: sub-100ms
+                docs: Original deadline budget was less than 100 milliseconds.
+              - value: sub-1s
+                docs: Original deadline budget was less than 1 second.
+              - value: sub-10s
+                docs: Original deadline budget was less than 10 seconds.
+              - value: sub-100s
+                docs: Original deadline budget was less than 100 seconds.
+              - value: above-100s
+                docs: Original deadline budget was 100 seconds or more.
+        docs: Records the original deadline budget bucket at the time of a deadline
+              expiration.

--- a/deadlines/src/main/metrics/deadlines-metrics.yml
+++ b/deadlines/src/main/metrics/deadlines-metrics.yml
@@ -38,3 +38,7 @@ namespaces:
                       the deadline expiration was reached. This means that further
                       RPC calls will not propagate an expired deadline value any more.
         docs: Marked every time a deadline expiration is reached
+      expired.budget:
+        type: histogram
+        docs: Records the original deadline budget (in nanoseconds) that was provided
+              to this service at the time of a deadline expiration.

--- a/deadlines/src/main/metrics/deadlines-metrics.yml
+++ b/deadlines/src/main/metrics/deadlines-metrics.yml
@@ -20,7 +20,7 @@ namespaces:
                       complete required work before a client-provided deadline elapses.
           - name: intent
             docs: Describes the intent (or not) to propagate an expired deadline on
-                 further RPC calls.
+                  further RPC calls.
             values:
               - value: throw
                 docs: Enforcement was enabled for this trace at the time the deadline
@@ -37,16 +37,10 @@ namespaces:
                 docs: Deadline propagation was disabled for this trace at the time
                       the deadline expiration was reached. This means that further
                       RPC calls will not propagate an expired deadline value any more.
-        docs: Marked every time a deadline expiration is reached
-      expired.budget:
-        type: meter
-        tags:
-          - name: bucket
+          - name: budget
+            docs: Records the original deadline budget bucket at the time of a deadline
+                  expiration.
             values:
-              - value: sub-1ms
-                docs: Original deadline budget was less than 1 millisecond.
-              - value: sub-10ms
-                docs: Original deadline budget was less than 10 milliseconds.
               - value: sub-100ms
                 docs: Original deadline budget was less than 100 milliseconds.
               - value: sub-1s
@@ -57,5 +51,4 @@ namespaces:
                 docs: Original deadline budget was less than 100 seconds.
               - value: above-100s
                 docs: Original deadline budget was 100 seconds or more.
-        docs: Records the original deadline budget bucket at the time of a deadline
-              expiration.
+        docs: Marked every time a deadline expiration is reached

--- a/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
+++ b/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.codahale.metrics.Meter;
+import com.palantir.deadlines.DeadlineMetrics.ExpiredBudget_Bucket;
 import com.palantir.deadlines.DeadlineMetrics.Expired_Cause;
 import com.palantir.deadlines.DeadlineMetrics.Expired_Intent;
 import com.palantir.deadlines.Deadlines.Enforcement;
@@ -1043,6 +1044,69 @@ class DeadlinesTest {
 
         // Without a trace, deadline state won't be set
         assertThat(Deadlines.getEnforcement()).isEmpty();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "0.0000005, SUB_1MS",
+        "0.005, SUB_10MS",
+        "0.05, SUB_100MS",
+        "0.5, SUB_1S",
+        "5.0, SUB_10S",
+        "50.0, SUB_100S",
+    })
+    public void expired_budget_meter_records_correct_bucket(
+            String deadlineSeconds, ExpiredBudget_Bucket expectedBucket) {
+        TestClock clock = new TestClock();
+        Deadlines.setClock(clock);
+        try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
+            Map<String, String> request = new HashMap<>();
+            request.put(DeadlinesHttpHeaders.EXPECT_WITHIN, deadlineSeconds);
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.DISABLE);
+
+            clock.elapsed += Long.MAX_VALUE;
+
+            @SuppressWarnings("for-rollout:deprecation")
+            DeadlineMetrics metrics = DeadlineMetrics.of(SharedTaggedMetricRegistries.getSingleton());
+            Meter expectedMeter = metrics.expiredBudget(expectedBucket);
+            long originalCount = expectedMeter.getCount();
+
+            Map<String, String> outbound = new HashMap<>();
+            Deadlines.encodeToRequest(
+                    Duration.ofSeconds(10), outbound, DummyRequestEncoder.INSTANCE, Enforcement.DEFER);
+
+            assertThat(expectedMeter.getCount()).isEqualTo(originalCount + 1);
+        }
+    }
+
+    @Test
+    public void expired_budget_meter_records_original_budget_not_remaining() {
+        TestClock clock = new TestClock();
+        Deadlines.setClock(clock);
+        try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
+            Map<String, String> request = new HashMap<>();
+            Duration providedDeadline = Duration.ofSeconds(5);
+            request.put(
+                    DeadlinesHttpHeaders.EXPECT_WITHIN, Deadlines.durationToHeaderValue(providedDeadline.toNanos()));
+            Deadlines.parseFromRequest(Optional.empty(), request, DummyRequestDecoder.INSTANCE, Enforcement.DISABLE);
+
+            clock.elapsed += 11_000_000_000L;
+
+            @SuppressWarnings("for-rollout:deprecation")
+            DeadlineMetrics metrics = DeadlineMetrics.of(SharedTaggedMetricRegistries.getSingleton());
+            Meter sub10sMeter = metrics.expiredBudget(ExpiredBudget_Bucket.SUB_10S);
+            Meter sub100sMeter = metrics.expiredBudget(ExpiredBudget_Bucket.SUB_100S);
+            long originalSub10s = sub10sMeter.getCount();
+            long originalSub100s = sub100sMeter.getCount();
+
+            Map<String, String> outbound = new HashMap<>();
+            Deadlines.encodeToRequest(
+                    Duration.ofSeconds(10), outbound, DummyRequestEncoder.INSTANCE, Enforcement.DEFER);
+
+            // Should record in sub-10s (original 5s budget), not any higher bucket
+            assertThat(sub10sMeter.getCount()).isEqualTo(originalSub10s + 1);
+            assertThat(sub100sMeter.getCount()).isEqualTo(originalSub100s);
+        }
     }
 
     private enum DummyRequestEncoder implements RequestEncodingAdapter<Map<String, String>> {

--- a/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
+++ b/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.codahale.metrics.Meter;
-import com.palantir.deadlines.DeadlineMetrics.ExpiredBudget_Bucket;
+import com.palantir.deadlines.DeadlineMetrics.Expired_Budget;
 import com.palantir.deadlines.DeadlineMetrics.Expired_Cause;
 import com.palantir.deadlines.DeadlineMetrics.Expired_Intent;
 import com.palantir.deadlines.Deadlines.Enforcement;
@@ -345,10 +345,12 @@ class DeadlinesTest {
             Meter externalMeter = metrics.expired()
                     .cause(Expired_Cause.EXTERNAL)
                     .intent(Expired_Intent.PROPAGATE)
+                    .budget(Expired_Budget.SUB_100MS)
                     .build();
             Meter internalMeter = metrics.expired()
                     .cause(Expired_Cause.INTERNAL)
                     .intent(Expired_Intent.PROPAGATE)
+                    .budget(Expired_Budget.SUB_100MS)
                     .build();
             long originalExternalValue = externalMeter.getCount();
             long originalInternalValue = internalMeter.getCount();
@@ -383,10 +385,12 @@ class DeadlinesTest {
             Meter externalMeter = metrics.expired()
                     .cause(Expired_Cause.EXTERNAL)
                     .intent(Expired_Intent.PROPAGATE)
+                    .budget(Expired_Budget.SUB_100MS)
                     .build();
             Meter internalMeter = metrics.expired()
                     .cause(Expired_Cause.INTERNAL)
                     .intent(Expired_Intent.PROPAGATE)
+                    .budget(Expired_Budget.SUB_100MS)
                     .build();
             long originalExternalValue = externalMeter.getCount();
             long originalInternalValue = internalMeter.getCount();
@@ -421,10 +425,12 @@ class DeadlinesTest {
             Meter externalMeterWillPropagate = metrics.expired()
                     .cause(Expired_Cause.EXTERNAL)
                     .intent(Expired_Intent.PROPAGATE)
+                    .budget(Expired_Budget.SUB_100MS)
                     .build();
             Meter externalMeterWontPropagate = metrics.expired()
                     .cause(Expired_Cause.EXTERNAL)
                     .intent(Expired_Intent.IGNORE)
+                    .budget(Expired_Budget.SUB_100MS)
                     .build();
             long originalWillPropagateValue = externalMeterWillPropagate.getCount();
             long originalWontPropagateValue = externalMeterWontPropagate.getCount();
@@ -500,10 +506,12 @@ class DeadlinesTest {
             Meter expiredMeterPropagateIntent = metrics.expired()
                     .cause(Expired_Cause.EXTERNAL)
                     .intent(Expired_Intent.PROPAGATE)
+                    .budget(Expired_Budget.SUB_100MS)
                     .build();
             Meter expiredMeterPropagateAlreadyExpiredIntent = metrics.expired()
                     .cause(Expired_Cause.EXTERNAL)
                     .intent(Expired_Intent.PROPAGATE_ALREADY_EXPIRED)
+                    .budget(Expired_Budget.SUB_100MS)
                     .build();
 
             long expiredMeterPropagateIntentValue = expiredMeterPropagateIntent.getCount();
@@ -572,6 +580,7 @@ class DeadlinesTest {
             Meter externalMeter = metrics.expired()
                     .cause(Expired_Cause.EXTERNAL)
                     .intent(Expired_Intent.THROW)
+                    .budget(Expired_Budget.SUB_100MS)
                     .build();
             long originalExternalValue = externalMeter.getCount();
 
@@ -1048,16 +1057,13 @@ class DeadlinesTest {
 
     @ParameterizedTest
     @CsvSource({
-        "0.0000005, SUB_1MS",
-        "0.005, SUB_10MS",
         "0.05, SUB_100MS",
         "0.5, SUB_1S",
         "5, SUB_10S",
         "50, SUB_100S",
         "500, ABOVE_100S",
     })
-    public void expired_budget_meter_records_correct_bucket(
-            String deadlineSeconds, ExpiredBudget_Bucket expectedBucket) {
+    public void expired_budget_meter_records_correct_bucket(String deadlineSeconds, Expired_Budget expectedBucket) {
         TestClock clock = new TestClock();
         Deadlines.setClock(clock);
         try (CloseableTracer tracer = CloseableTracer.startSpan("test")) {
@@ -1069,7 +1075,11 @@ class DeadlinesTest {
 
             @SuppressWarnings("for-rollout:deprecation")
             DeadlineMetrics metrics = DeadlineMetrics.of(SharedTaggedMetricRegistries.getSingleton());
-            Meter expectedMeter = metrics.expiredBudget(expectedBucket);
+            Meter expectedMeter = metrics.expired()
+                    .cause(Expired_Cause.EXTERNAL)
+                    .intent(Expired_Intent.PROPAGATE)
+                    .budget(expectedBucket)
+                    .build();
             long originalCount = expectedMeter.getCount();
 
             Map<String, String> outbound = new HashMap<>();
@@ -1095,8 +1105,16 @@ class DeadlinesTest {
 
             @SuppressWarnings("for-rollout:deprecation")
             DeadlineMetrics metrics = DeadlineMetrics.of(SharedTaggedMetricRegistries.getSingleton());
-            Meter sub10sMeter = metrics.expiredBudget(ExpiredBudget_Bucket.SUB_10S);
-            Meter sub100sMeter = metrics.expiredBudget(ExpiredBudget_Bucket.SUB_100S);
+            Meter sub10sMeter = metrics.expired()
+                    .cause(Expired_Cause.EXTERNAL)
+                    .intent(Expired_Intent.PROPAGATE)
+                    .budget(Expired_Budget.SUB_10S)
+                    .build();
+            Meter sub100sMeter = metrics.expired()
+                    .cause(Expired_Cause.EXTERNAL)
+                    .intent(Expired_Intent.PROPAGATE)
+                    .budget(Expired_Budget.SUB_100S)
+                    .build();
             long originalSub10s = sub10sMeter.getCount();
             long originalSub100s = sub100sMeter.getCount();
 

--- a/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
+++ b/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
@@ -1052,8 +1052,9 @@ class DeadlinesTest {
         "0.005, SUB_10MS",
         "0.05, SUB_100MS",
         "0.5, SUB_1S",
-        "5.0, SUB_10S",
-        "50.0, SUB_100S",
+        "5, SUB_10S",
+        "50, SUB_100S",
+        "500, ABOVE_100S",
     })
     public void expired_budget_meter_records_correct_bucket(
             String deadlineSeconds, ExpiredBudget_Bucket expectedBucket) {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
When a deadline expiration is observed, marks the original deadline budget. When expirations happen, we can then tell if the budget was too short or the service was too slow. 

I think that's better than recording the elapsed time before a deadline was thrown, because that's only telling us how slow the service was - we can already get that from endpoint req latency metrics / it doesn't necessarily give us the unique signal from a deadlines perspective.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Adds a metric for initial deadline budget on expiration.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

