### PR TITLE
Use quicktheories for property-based testing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,12 +51,6 @@ allprojects {
 
     group 'com.palantir.deadlines'
     version System.env.CIRCLE_TAG ?: rootProject.version
-
-    tasks.withType(Test).configureEach {
-        useJUnitPlatform {
-            includeEngines 'jqwik', 'junit-jupiter'
-        }
-    }
 }
 
 jdks {

--- a/deadlines/build.gradle
+++ b/deadlines/build.gradle
@@ -11,12 +11,10 @@ dependencies {
     implementation 'com.palantir.safe-logging:safe-logging'
 
     // for VisibleForTesting annotation
-    compileOnly "com.google.guava:guava"
+    compileOnly 'com.google.guava:guava'
 
-    testImplementation "org.junit.jupiter:junit-jupiter"
-    testImplementation "org.assertj:assertj-core"
-    testImplementation 'net.jqwik:jqwik-api'
-
-    testRuntimeOnly 'net.jqwik:jqwik'
+    testImplementation 'org.assertj:assertj-core'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation 'org.quicktheories:quicktheories'
 }
 

--- a/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
+++ b/deadlines/src/test/java/com/palantir/deadlines/DeadlinesTest.java
@@ -20,6 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.quicktheories.QuickTheory.qt;
+import static org.quicktheories.generators.SourceDSL.lists;
 
 import com.codahale.metrics.Meter;
 import com.palantir.deadlines.DeadlineMetrics.Expired_Budget;
@@ -37,18 +39,12 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
-import net.jqwik.api.ForAll;
-import net.jqwik.api.GenerationMode;
-import net.jqwik.api.Property;
-import net.jqwik.api.constraints.AlphaChars;
-import net.jqwik.api.constraints.LowerChars;
-import net.jqwik.api.constraints.NumericChars;
-import net.jqwik.api.constraints.StringLength;
-import net.jqwik.api.constraints.Whitespace;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.quicktheories.core.Gen;
+import org.quicktheories.generators.Generate;
 
 class DeadlinesTest {
 
@@ -155,28 +151,43 @@ class DeadlinesTest {
         assertThat(Deadlines.tryParseSecondsToNanoseconds(headerValue)).isNull();
     }
 
-    @Property(tries = 100_000, generation = GenerationMode.AUTO)
-    void check_tryParseSecondsToNanoseconds_successfully_parses_numeric_values(
-            @ForAll @NumericChars @StringLength(min = 1, max = 100) String integer,
-            @ForAll @NumericChars @StringLength(min = 1, max = 100) String decimal) {
-        assertThat(Deadlines.tryParseSecondsToNanoseconds(integer))
-                .isNotNull()
-                .isGreaterThanOrEqualTo(0)
-                .isLessThanOrEqualTo(Long.MAX_VALUE);
-        assertThat(Deadlines.tryParseSecondsToNanoseconds(decimal))
-                .isNotNull()
-                .isGreaterThanOrEqualTo(0)
-                .isLessThanOrEqualTo(Long.MAX_VALUE);
-        assertThat(Deadlines.tryParseSecondsToNanoseconds(integer + '.' + decimal))
-                .isNotNull()
-                .isGreaterThanOrEqualTo(0)
-                .isLessThanOrEqualTo(Long.MAX_VALUE);
+    @Test
+    void check_tryParseSecondsToNanoseconds_successfully_parses_numeric_values() {
+        Gen<String> numericStringGen = stringGen("0123456789", 1, 100);
+        qt().withExamples(100_000).forAll(numericStringGen, numericStringGen).checkAssert((integer, decimal) -> {
+            assertThat(Deadlines.tryParseSecondsToNanoseconds(integer))
+                    .isNotNull()
+                    .isGreaterThanOrEqualTo(0)
+                    .isLessThanOrEqualTo(Long.MAX_VALUE);
+            assertThat(Deadlines.tryParseSecondsToNanoseconds(decimal))
+                    .isNotNull()
+                    .isGreaterThanOrEqualTo(0)
+                    .isLessThanOrEqualTo(Long.MAX_VALUE);
+            assertThat(Deadlines.tryParseSecondsToNanoseconds(integer + '.' + decimal))
+                    .isNotNull()
+                    .isGreaterThanOrEqualTo(0)
+                    .isLessThanOrEqualTo(Long.MAX_VALUE);
+        });
     }
 
-    @Property(tries = 100_000, generation = GenerationMode.AUTO)
-    void check_tryParseSecondsToNanoseconds_handles_inputs(
-            @ForAll @AlphaChars @NumericChars @Whitespace @LowerChars @StringLength(min = 0, max = 100) String input) {
-        assertThatCode(() -> Deadlines.tryParseSecondsToNanoseconds(input)).doesNotThrowAnyException();
+    @Test
+    void check_tryParseSecondsToNanoseconds_handles_inputs() {
+        Gen<String> stringGen =
+                stringGen("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 \t\n\r", 0, 100);
+        qt().withExamples(100_000)
+                .forAll(stringGen)
+                .checkAssert(input -> assertThatCode(() -> Deadlines.tryParseSecondsToNanoseconds(input))
+                        .doesNotThrowAnyException());
+    }
+
+    private static Gen<String> stringGen(String validChars, int minLength, int maxLength) {
+        Gen<Character> characterGen =
+                Generate.pick(validChars.chars().mapToObj(c -> (char) c).toList());
+        return lists().of(characterGen).ofSizeBetween(minLength, maxLength).map(chars -> {
+            StringBuilder sb = new StringBuilder(chars.size());
+            chars.forEach(sb::append);
+            return sb.toString();
+        });
     }
 
     @Test

--- a/versions.lock
+++ b/versions.lock
@@ -76,17 +76,7 @@ org.wildfly.common:wildfly-common:2.0.1 (1 constraints: be0d0b36)
 
 net.bytebuddy:byte-buddy:1.18.3 (1 constraints: 530b55df)
 
-net.jqwik:jqwik:1.10.1 (1 constraints: 35052a3b)
-
-net.jqwik:jqwik-api:1.10.1 (5 constraints: 332a7a57)
-
-net.jqwik:jqwik-engine:1.10.1 (1 constraints: c607ad74)
-
-net.jqwik:jqwik-time:1.10.1 (1 constraints: c607ad74)
-
-net.jqwik:jqwik-web:1.10.1 (1 constraints: c607ad74)
-
-org.apiguardian:apiguardian-api:1.1.2 (11 constraints: 9293fa1e)
+org.apiguardian:apiguardian-api:1.1.2 (6 constraints: 5366ce6e)
 
 org.assertj:assertj-core:3.27.7 (1 constraints: 4505553b)
 
@@ -98,10 +88,12 @@ org.junit.jupiter:junit-jupiter-engine:6.1.0 (1 constraints: 040ecd3b)
 
 org.junit.jupiter:junit-jupiter-params:6.1.0 (1 constraints: 040ecd3b)
 
-org.junit.platform:junit-platform-commons:6.1.0 (4 constraints: 7734b3f3)
+org.junit.platform:junit-platform-commons:6.1.0 (2 constraints: d5204b4a)
 
-org.junit.platform:junit-platform-engine:6.1.0 (3 constraints: 5c2d6fc9)
+org.junit.platform:junit-platform-engine:6.1.0 (2 constraints: ed22e007)
 
 org.junit.platform:junit-platform-launcher:6.1.0 (1 constraints: 09050c36)
 
-org.opentest4j:opentest4j:1.3.0 (6 constraints: 7846fee1)
+org.opentest4j:opentest4j:1.3.0 (2 constraints: cf209249)
+
+org.quicktheories:quicktheories:0.26 (1 constraints: dc04f530)

--- a/versions.props
+++ b/versions.props
@@ -5,7 +5,7 @@ com.palantir.tracing:* = 6.35.0
 com.palantir.tritium:* = 0.130.0
 
 # test dependencies
-net.jqwik:* = 1.10.1
+org.quicktheories:quicktheories = 0.26
 org.assertj:assertj-core = 3.27.7
 org.junit.jupiter:* = 6.1.0
 org.junit.platform:* = 6.1.0


### PR DESCRIPTION
## Summary
- Replace jqwik with [QuickTheories](https://github.com/quicktheories/QuickTheories) for property-based testing
- Convert two `@Property` tests in `DeadlinesTest` to `@Test` methods using `qt().withExamples().forAll().checkAssert()`
- Remove jqwik test engine configuration from root `build.gradle`

See https://github.com/palantir/tritium/issues/2472

## Test plan
- [x] `./gradlew build` passes
- [x] Property-based tests run with 100,000 examples each

🤖 Generated with [Claude Code](https://claude.com/claude-code)